### PR TITLE
fix(fetcher): treat low-signal X posts as failed

### DIFF
--- a/src/content_fetcher.py
+++ b/src/content_fetcher.py
@@ -7,6 +7,11 @@ import requests
 from slugify import slugify
 
 try:
+    from x_content_fetcher import X_HOSTS, XContentError, fetch_x_text
+except ImportError:
+    from src.x_content_fetcher import X_HOSTS, XContentError, fetch_x_text
+
+try:
     import trafilatura
 except ImportError:
     class _TrafilaturaFallback:
@@ -39,10 +44,13 @@ YOUTUBE_HOSTS = {
 }
 
 
+
 def classify_url(url: str) -> str:
     host = (urlparse(url).hostname or "").lower()
     if host in YOUTUBE_HOSTS:
         return "youtube"
+    if host in X_HOSTS:
+        return "x_post"
     return "article"
 
 
@@ -94,13 +102,11 @@ def write_failure_record(
     return out_path
 
 
-def fetch_url(url: str, failed_base_dir: str = "data/failed") -> Dict[str, Any]:
-    kind = classify_url(url)
-    if kind == "youtube":
-        return {"status": "ignored", "kind": "youtube", "url": url}
-
+def _fetch_and_record(
+    url: str, fetcher: Any, failed_base_dir: str
+) -> Dict[str, Any]:
     try:
-        content = fetch_article_text(url)
+        content = fetcher(url)
     except Exception as exc:  # noqa: BLE001
         failure_path = write_failure_record(url=url, error=str(exc), base_dir=failed_base_dir)
         return {
@@ -110,8 +116,18 @@ def fetch_url(url: str, failed_base_dir: str = "data/failed") -> Dict[str, Any]:
             "error": str(exc),
             "failure_path": str(failure_path),
         }
-
     return {"status": "ok", "kind": "article", "url": url, "content": content}
+
+
+def fetch_url(url: str, failed_base_dir: str = "data/failed") -> Dict[str, Any]:
+    kind = classify_url(url)
+    if kind == "youtube":
+        return {"status": "ignored", "kind": "youtube", "url": url}
+
+    if kind == "x_post":
+        return _fetch_and_record(url, fetch_x_text, failed_base_dir)
+
+    return _fetch_and_record(url, fetch_article_text, failed_base_dir)
 
 
 def fetch_urls(urls: Iterable[str], failed_base_dir: str = "data/failed") -> List[Dict[str, Any]]:

--- a/src/x_content_fetcher.py
+++ b/src/x_content_fetcher.py
@@ -1,0 +1,198 @@
+import html
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+
+X_HOSTS = {
+    "x.com",
+    "www.x.com",
+    "twitter.com",
+    "www.twitter.com",
+    "mobile.twitter.com",
+    "mobile.x.com",
+}
+
+X_CONTENT_UNAVAILABLE = "x_content_unavailable"
+X_INTERSTITIAL_DETECTED = "x_interstitial_detected"
+X_LOW_SIGNAL_CONTENT = "x_low_signal_content"
+
+
+class XContentError(RuntimeError):
+    def __init__(self, reason: str, message: str = "") -> None:
+        self.reason = reason
+        final_message = reason if not message else f"{reason}: {message}"
+        super().__init__(final_message)
+
+
+def parse_tweet_id(url: str) -> str | None:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in X_HOSTS:
+        return None
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 3:
+        return None
+
+    for index, part in enumerate(parts):
+        if part != "status":
+            continue
+        if index + 1 >= len(parts):
+            return None
+        candidate = parts[index + 1]
+        if candidate.isdigit():
+            return candidate
+        return None
+    return None
+
+
+def _is_interstitial_text(text: str) -> bool:
+    lowered = text.lower()
+    signals = (
+        "javascript is disabled",
+        "enable javascript",
+        "javascript is not available",
+        "supported browser",
+        "log in to x",
+        "sign in to x",
+        "access denied",
+    )
+    return any(signal in lowered for signal in signals)
+
+
+def _is_low_signal_text(text: str) -> bool:
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if not cleaned:
+        return True
+
+    if _is_interstitial_text(cleaned):
+        return False
+
+    if len(cleaned) < 12:
+        return True
+
+    without_urls = re.sub(r"https?://\S+", "", cleaned)
+    without_urls = re.sub(r"t\.co/\S+", "", without_urls)
+    letters = re.findall(r"[A-Za-z0-9]", without_urls)
+    return len(letters) < 12
+
+
+def _validate_text(text: str) -> str:
+    normalized = re.sub(r"\s+", " ", text).strip()
+    if not normalized:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "empty response")
+    if _is_interstitial_text(normalized):
+        raise XContentError(X_INTERSTITIAL_DETECTED, "access wall or JS interstitial")
+    if _is_low_signal_text(normalized):
+        raise XContentError(X_LOW_SIGNAL_CONTENT, "content lacks substantive text")
+    return normalized
+
+
+def _normalize_syndication_payload(payload: dict[str, Any]) -> str:
+    candidates: list[str] = []
+    for key in ("text", "full_text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+
+    user = payload.get("user")
+    if isinstance(user, dict):
+        screen_name = user.get("screen_name") or user.get("name")
+        if isinstance(screen_name, str):
+            candidates.append("Author: " + screen_name)
+
+    created_at = payload.get("created_at")
+    if isinstance(created_at, str) and created_at.strip():
+        candidates.append("Posted: " + created_at.strip())
+
+    return "\n".join(item.strip() for item in candidates if item.strip()).strip()
+
+
+def _normalize_oembed_payload(payload: dict[str, Any]) -> str:
+    pieces: list[str] = []
+    author = payload.get("author_name")
+    if isinstance(author, str) and author.strip():
+        pieces.append("Author: " + author.strip())
+
+    html_block = payload.get("html")
+    if isinstance(html_block, str) and html_block.strip():
+        match = re.search(r"<p[^>]*>(.*?)</p>", html_block, flags=re.IGNORECASE | re.DOTALL)
+        if match:
+            inner = match.group(1)
+            inner = re.sub(r"<[^>]+>", " ", inner)
+            inner = html.unescape(inner)
+            pieces.append(re.sub(r"\s+", " ", inner).strip())
+
+    return "\n".join(item for item in pieces if item).strip()
+
+
+def _fetch_syndication(tweet_id: str, timeout: tuple[int, int]) -> dict[str, Any]:
+    try:
+        response = requests.get(
+            "https://cdn.syndication.twimg.com/tweet-result",
+            params={"id": tweet_id, "lang": "en"},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "syndication_request_failed") from exc
+    if response.status_code >= 400:
+        raise XContentError(X_CONTENT_UNAVAILABLE, f"syndication_http_{response.status_code}")
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "syndication_invalid_json") from exc
+
+    if not isinstance(payload, dict):
+        raise XContentError(X_CONTENT_UNAVAILABLE, "syndication_invalid_payload")
+    return payload
+
+
+def _fetch_oembed(url: str, timeout: tuple[int, int]) -> dict[str, Any]:
+    try:
+        response = requests.get(
+            "https://publish.twitter.com/oembed",
+            params={"url": url},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "oembed_request_failed") from exc
+    if response.status_code >= 400:
+        raise XContentError(X_CONTENT_UNAVAILABLE, f"oembed_http_{response.status_code}")
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "oembed_invalid_json") from exc
+
+    if not isinstance(payload, dict):
+        raise XContentError(X_CONTENT_UNAVAILABLE, "oembed_invalid_payload")
+    return payload
+
+
+def fetch_x_text(url: str, timeout: tuple[int, int] = (10, 30)) -> str:
+    tweet_id = parse_tweet_id(url)
+    if not tweet_id:
+        raise XContentError(X_CONTENT_UNAVAILABLE, "tweet_id_missing")
+
+    syndication_error: XContentError | None = None
+    try:
+        syndication_payload = _fetch_syndication(tweet_id=tweet_id, timeout=timeout)
+        syndication_text = _normalize_syndication_payload(syndication_payload)
+        return _validate_text(syndication_text)
+    except XContentError as exc:
+        syndication_error = exc
+
+    try:
+        oembed_payload = _fetch_oembed(url=url, timeout=timeout)
+        oembed_text = _normalize_oembed_payload(oembed_payload)
+        return _validate_text(oembed_text)
+    except XContentError as exc:
+        fallback_error = exc
+        detail = f"syndication={syndication_error}; oembed={fallback_error}"
+        if fallback_error.reason in {X_INTERSTITIAL_DETECTED, X_LOW_SIGNAL_CONTENT}:
+            raise XContentError(fallback_error.reason, detail) from fallback_error
+        raise XContentError(X_CONTENT_UNAVAILABLE, detail) from fallback_error

--- a/tests/test_content_fetcher.py
+++ b/tests/test_content_fetcher.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.content_fetcher import classify_url, fetch_url, write_failure_record
+from src.x_content_fetcher import XContentError, X_LOW_SIGNAL_CONTENT
 
 
 class ContentFetcherTests(unittest.TestCase):
@@ -12,6 +13,10 @@ class ContentFetcherTests(unittest.TestCase):
         self.assertEqual(classify_url("https://www.youtube.com/watch?v=abc"), "youtube")
         self.assertEqual(classify_url("https://youtu.be/abc"), "youtube")
         self.assertEqual(classify_url("https://example.com/article"), "article")
+
+    def test_classify_x_urls(self) -> None:
+        self.assertEqual(classify_url("https://x.com/user/status/123"), "x_post")
+        self.assertEqual(classify_url("https://twitter.com/user/status/123"), "x_post")
 
     def test_fetch_url_youtube_is_ignored(self) -> None:
         result = fetch_url("https://youtu.be/abc")
@@ -44,6 +49,29 @@ class ContentFetcherTests(unittest.TestCase):
 
             self.assertEqual(result["status"], "failed")
             self.assertIn("failure_path", result)
+            self.assertTrue(Path(result["failure_path"]).exists())
+
+    @patch("src.content_fetcher.fetch_x_text")
+    def test_fetch_url_x_post_routes_to_x_fetcher(self, mock_fetch_x_text) -> None:
+        mock_fetch_x_text.return_value = "substantive tweet text"
+
+        result = fetch_url("https://x.com/user/status/123")
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["kind"], "article")
+        self.assertIn("content", result)
+        mock_fetch_x_text.assert_called_once_with("https://x.com/user/status/123")
+
+    @patch("src.content_fetcher.fetch_x_text")
+    def test_fetch_url_x_post_failure_is_failed_with_record(self, mock_fetch_x_text) -> None:
+        mock_fetch_x_text.side_effect = XContentError(X_LOW_SIGNAL_CONTENT, "link-only")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = fetch_url("https://x.com/user/status/123", failed_base_dir=tmpdir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertEqual(result["kind"], "article")
+            self.assertIn(X_LOW_SIGNAL_CONTENT, result["error"])
             self.assertTrue(Path(result["failure_path"]).exists())
 
     def test_write_failure_record_path_structure(self) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,6 +88,56 @@ class MainPipelineOutcomeTests(unittest.TestCase):
     @patch("src.main.summarize_items")
     @patch("src.main.fetch_urls")
     @patch("src.main.poll_urls_from_env")
+    def test_run_pipeline_counts_failed_article_items(
+        self,
+        mock_poll_urls_from_env,
+        mock_fetch_urls,
+        mock_summarize_items,
+        mock_generate_digest,
+        mock_send_digest_from_env,
+    ) -> None:
+        mock_poll_urls_from_env.return_value = {
+            "urls": ["https://x.com/user/status/123"],
+            "update_count": 1,
+            "previous_offset": 10,
+            "next_offset": 11,
+        }
+        mock_fetch_urls.return_value = [
+            {
+                "status": "failed",
+                "kind": "article",
+                "url": "https://x.com/user/status/123",
+                "error": "x_low_signal_content",
+                "failure_path": "data/failed/2026-03-15/x.md",
+            }
+        ]
+        mock_summarize_items.return_value = [
+            {
+                "status": "failed",
+                "kind": "article",
+                "url": "https://x.com/user/status/123",
+                "error": "x_low_signal_content",
+                "failure_path": "data/failed/2026-03-15/x.md",
+            }
+        ]
+        mock_generate_digest.return_value = {
+            "digest_path": "data/digests/2026-03-15.md",
+            "digest_text": "digest body",
+        }
+        mock_send_digest_from_env.return_value = [{"ok": True}]
+
+        outcome = run_pipeline(now=datetime(2026, 3, 15, tzinfo=timezone.utc))
+
+        self.assertEqual(outcome["processed_urls"], 1)
+        self.assertEqual(outcome["summary_ok_count"], 0)
+        self.assertEqual(outcome["summary_failed_count"], 1)
+        self.assertEqual(outcome["digest_created"], True)
+
+    @patch("src.main.send_digest_from_env")
+    @patch("src.main.generate_digest")
+    @patch("src.main.summarize_items")
+    @patch("src.main.fetch_urls")
+    @patch("src.main.poll_urls_from_env")
     def test_run_pipeline_skips_when_only_ignored_urls(
         self,
         mock_poll_urls_from_env,

--- a/tests/test_x_content_fetcher.py
+++ b/tests/test_x_content_fetcher.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from src.x_content_fetcher import (
+    X_CONTENT_UNAVAILABLE,
+    X_INTERSTITIAL_DETECTED,
+    X_LOW_SIGNAL_CONTENT,
+    XContentError,
+    fetch_x_text,
+    parse_tweet_id,
+)
+
+
+def _response(payload: object, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+class XContentFetcherTests(unittest.TestCase):
+    def test_parse_tweet_id_variants(self) -> None:
+        self.assertEqual(parse_tweet_id("https://x.com/user/status/1234567890"), "1234567890")
+        self.assertEqual(parse_tweet_id("https://twitter.com/user/status/1234567890?s=20"), "1234567890")
+        self.assertEqual(parse_tweet_id("https://www.x.com/user/status/1234567890"), "1234567890")
+        self.assertIsNone(parse_tweet_id("https://x.com/home"))
+        self.assertIsNone(parse_tweet_id("https://example.com/user/status/1234567890"))
+
+    def test_fetch_x_text_missing_tweet_id(self) -> None:
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://x.com/home")
+
+        self.assertEqual(ctx.exception.reason, X_CONTENT_UNAVAILABLE)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_syndication_success(self, mock_get) -> None:
+        mock_get.return_value = _response({"text": "This is a substantive tweet about test automation and reliability."})
+
+        text = fetch_x_text("https://x.com/user/status/1234567890")
+
+        self.assertIn("substantive tweet", text)
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_falls_back_to_oembed(self, mock_get) -> None:
+        mock_get.side_effect = [
+            _response({}),
+            _response(
+                {
+                    "author_name": "Alice",
+                    "html": "<blockquote><p>Ship useful software every day with clear quality gates.</p></blockquote>",
+                }
+            ),
+        ]
+
+        text = fetch_x_text("https://x.com/user/status/1234567890")
+
+        self.assertIn("Author: Alice", text)
+        self.assertIn("Ship useful software", text)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_interstitial_detected(self, mock_get) -> None:
+        mock_get.side_effect = [
+            _response({"text": "JavaScript is disabled in this browser. Please enable JavaScript."}),
+            _response({"author_name": "Alice", "html": "<blockquote><p>https://t.co/abc</p></blockquote>"}),
+        ]
+
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://x.com/user/status/1234567890")
+
+        self.assertEqual(ctx.exception.reason, X_LOW_SIGNAL_CONTENT)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_low_signal_content(self, mock_get) -> None:
+        mock_get.side_effect = [
+            _response({"text": "https://t.co/abc"}),
+            _response({"author_name": "Alice", "html": "<blockquote><p>https://t.co/abc</p></blockquote>"}),
+        ]
+
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://x.com/user/status/1234567890")
+
+        self.assertEqual(ctx.exception.reason, X_LOW_SIGNAL_CONTENT)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_content_unavailable(self, mock_get) -> None:
+        mock_get.side_effect = [
+            _response({}, status_code=404),
+            _response({}, status_code=404),
+        ]
+
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://x.com/user/status/1234567890")
+
+        self.assertEqual(ctx.exception.reason, X_CONTENT_UNAVAILABLE)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_interstitial_reason_survives(self, mock_get) -> None:
+        mock_get.side_effect = [
+            _response({}),
+            _response({"author_name": "X", "html": "<blockquote><p>Enable JavaScript to view this content</p></blockquote>"}),
+        ]
+
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://twitter.com/user/status/1234567890")
+
+        self.assertEqual(ctx.exception.reason, X_INTERSTITIAL_DETECTED)
+
+    @patch("src.x_content_fetcher.requests.get")
+    def test_fetch_x_text_request_exception_becomes_content_unavailable(self, mock_get) -> None:
+        mock_get.side_effect = requests.RequestException("boom")
+
+        with self.assertRaises(XContentError) as ctx:
+            fetch_x_text("https://twitter.com/user/status/1234567890")
+
+        self.assertEqual(ctx.exception.reason, X_CONTENT_UNAVAILABLE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a modular X content fetcher with syndication-to-oEmbed fallback and quality gates to prevent interstitial or metadata-only pages from being marked successful summaries. Route x.com/twitter.com through the new module and extend tests so failed X article items are counted correctly in pipeline outcomes.