### PR TITLE
Docs: standardize local setup baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: setup test run
+
+setup:
+	uv sync --frozen
+	uv run python -m playwright install chromium
+	git config core.hooksPath .githooks
+
+test:
+	uv run python -m unittest discover -s tests -p "test_*.py"
+
+run:
+	uv run python -m src

--- a/README.md
+++ b/README.md
@@ -89,42 +89,43 @@ User -> Telegram Bot
 - Successful runs with output changes create a standard daily commit and push it
 - Telemetry and run-history reporting are non-blocking; they do not prevent digest persistence
 
-## Local verification
+## Local environment setup
 
 Install `uv` first: https://docs.astral.sh/uv/getting-started/installation/
 
 ```bash
-uv sync --frozen
-uv run python -m unittest discover -s tests -p "test_*.py"
-uv run python -m src
+make setup
 ```
 
-Enable repository hooks once per clone:
+`make setup` syncs dependencies, installs the browser runtime used by local automation flows, and enables repository hooks.
 
-```bash
-git config core.hooksPath .githooks
-```
+Set the environment variables required by your local run.
 
-Required environment variables:
+Minimum baseline:
 
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_CHAT_ID`
 - `OPENROUTER_API_KEY`
 
-NotebookLM authentication is also required for YouTube summarization and NotebookLM article fallback. Configure one of:
+## Local verification
 
-- `NOTEBOOKLM_STORAGE_STATE`, or
-- `NOTEBOOKLM_STORAGE_PATH`, or
-- local `~/.notebooklm/storage_state.json` from `notebooklm login`
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"
+uv run python -m src
+```
 
-Optional NotebookLM auth preflight mode:
+Common shortcuts:
 
-- `NOTEBOOKLM_PREFLIGHT_MODE` = `enforce` (workflow default), `observe`, or `off`
+```bash
+make test
+make run
+```
 
-Replay recovery workflow:
+Common setup issues:
 
-- run `.github/workflows/replay-notebooklm.yml` manually after credential refresh
-- replay queue artifacts live under `data/replay/notebooklm/pending/` and `data/replay/notebooklm/completed/`
+- Python version mismatch (`requires-python >=3.11,<3.12`)
+- Missing environment variables
+- Lockfile drift (rerun `uv sync --frozen`)
 
 ## Documentation
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,7 +47,7 @@ This playbook covers the common failures for the live workflow in `.github/workf
 - Acknowledge:
   - Workflow warning annotation appears when `notebooklm_auth_incident=true`.
 - Remediate:
-  - Run `notebooklm login` locally.
+  - Run `uv run notebooklm login` locally.
   - Update `NOTEBOOKLM_STORAGE_STATE` secret with fresh storage state JSON.
 - Validate:
   - Manual rerun reports `NotebookLM preflight status: ok` and `NotebookLM auth failures: 0`.

--- a/docs/runbooks/notebooklm-auth-renewal.md
+++ b/docs/runbooks/notebooklm-auth-renewal.md
@@ -41,14 +41,14 @@ Run this playbook when one or more are true:
 1. Refresh local NotebookLM session.
 
    ```bash
-   notebooklm login
+   uv run notebooklm login
    ```
 
 2. Validate the refreshed state file exists and is valid JSON.
 
    ```bash
    test -f ~/.notebooklm/storage_state.json
-   python -m json.tool ~/.notebooklm/storage_state.json >/dev/null
+   uv run python -m json.tool ~/.notebooklm/storage_state.json >/dev/null
    ```
 
 3. Rotate `NOTEBOOKLM_STORAGE_STATE` in GitHub Actions.

--- a/docs/youtube-investigation.md
+++ b/docs/youtube-investigation.md
@@ -60,18 +60,18 @@ Pasting a YouTube URL into Gemini (tested via the web UI) resulted in the model 
 
 **Validated end-to-end:** We tested `https://youtu.be/l8pQeVVaqpY` via the `notebooklm` CLI:
 
-```
-notebooklm create "test-yt"
+```bash
+uv run notebooklm create "test-yt"
 # → Created notebook: ad16e0d3-6686-49ce-abc5-37ca8051809c
-notebooklm source add "https://youtu.be/l8pQeVVaqpY"
-notebooklm ask "Summarize this video in key points"
+uv run notebooklm source add "https://youtu.be/l8pQeVVaqpY"
+uv run notebooklm ask "Summarize this video in key points"
 ```
 
 The summary was accurate and specific, confirming that NotebookLM correctly accessed and understood the video content.
 
 **Trade-offs:**
 - Requires a Google account and a saved auth session (`storage_state.json`)
-- Auth sessions expire periodically — renewal is manual (`notebooklm login`)
+- Auth sessions expire periodically — renewal is manual (`uv run notebooklm login`)
 - Uses undocumented Google APIs that may change without notice
 - Each video summarization creates and deletes a temporary notebook (overhead: a few extra API calls)
 - Not suitable if the Google account is rate-limited or suspended

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "requests==2.32.5",
     "python-slugify==8.0.4",
     "notebooklm-py==0.3.4",
+    "playwright==1.55.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,24 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -265,12 +283,52 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/3a/c81ff76df266c62e24f19718df9c168f49af93cabdbc4608ae29656a9986/playwright-1.55.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d7da108a95001e412effca4f7610de79da1637ccdf670b1ae3fdc08b9694c034", size = 40428109, upload-time = "2025-08-28T15:46:20.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f5/bdb61553b20e907196a38d864602a9b4a461660c3a111c67a35179b636fa/playwright-1.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8290cf27a5d542e2682ac274da423941f879d07b001f6575a5a3a257b1d4ba1c", size = 38687254, upload-time = "2025-08-28T15:46:23.925Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/64/48b2837ef396487807e5ab53c76465747e34c7143fac4a084ef349c293a8/playwright-1.55.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:25b0d6b3fd991c315cca33c802cf617d52980108ab8431e3e1d37b5de755c10e", size = 40428108, upload-time = "2025-08-28T15:46:27.119Z" },
+    { url = "https://files.pythonhosted.org/packages/08/33/858312628aa16a6de97839adc2ca28031ebc5391f96b6fb8fdf1fcb15d6c/playwright-1.55.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c6d4d8f6f8c66c483b0835569c7f0caa03230820af8e500c181c93509c92d831", size = 45905643, upload-time = "2025-08-28T15:46:30.312Z" },
+    { url = "https://files.pythonhosted.org/packages/83/83/b8d06a5b5721931aa6d5916b83168e28bd891f38ff56fe92af7bdee9860f/playwright-1.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29a0777c4ce1273acf90c87e4ae2fe0130182100d99bcd2ae5bf486093044838", size = 45296647, upload-time = "2025-08-28T15:46:33.221Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2e/9db64518aebcb3d6ef6cd6d4d01da741aff912c3f0314dadb61226c6a96a/playwright-1.55.0-py3-none-win32.whl", hash = "sha256:29e6d1558ad9d5b5c19cbec0a72f6a2e35e6353cd9f262e22148685b86759f90", size = 35476046, upload-time = "2025-08-28T15:46:36.184Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4f/9ba607fa94bb9cee3d4beb1c7b32c16efbfc9d69d5037fa85d10cafc618b/playwright-1.55.0-py3-none-win_amd64.whl", hash = "sha256:7eb5956473ca1951abb51537e6a0da55257bb2e25fc37c2b75af094a5c93736c", size = 35476048, upload-time = "2025-08-28T15:46:38.867Z" },
+    { url = "https://files.pythonhosted.org/packages/21/98/5ca173c8ec906abde26c28e1ecb34887343fd71cc4136261b90036841323/playwright-1.55.0-py3-none-win_arm64.whl", hash = "sha256:012dc89ccdcbd774cdde8aeee14c08e0dd52ddb9135bf10e9db040527386bd76", size = 31225543, upload-time = "2025-08-28T15:46:41.613Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/43/4026f6ee056306d0e0eb04fcb9f2122a0f1a5c57ad9dc5e0d67399e47194/pypdf-5.4.0.tar.gz", hash = "sha256:9af476a9dc30fcb137659b0dec747ea94aa954933c52cf02ee33e39a16fe9175", size = 5012492, upload-time = "2025-03-16T09:44:11.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/27/d83f8f2a03ca5408dc2cc84b49c0bf3fbf059398a6a2ea7c10acfe28859f/pypdf-5.4.0-py3-none-any.whl", hash = "sha256:db994ab47cadc81057ea1591b90e5b543e2b7ef2d0e31ef41a9bfe763c119dab", size = 302306, upload-time = "2025-03-16T09:44:09.757Z" },
 ]
 
 [[package]]
@@ -392,6 +450,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "lxml-html-clean" },
     { name = "notebooklm-py" },
+    { name = "playwright" },
+    { name = "pypdf" },
     { name = "python-slugify" },
     { name = "requests" },
     { name = "trafilatura" },
@@ -401,6 +461,8 @@ dependencies = [
 requires-dist = [
     { name = "lxml-html-clean", specifier = "==0.4.4" },
     { name = "notebooklm-py", specifier = "==0.3.4" },
+    { name = "playwright", specifier = "==1.55.0" },
+    { name = "pypdf", specifier = "==5.4.0" },
     { name = "python-slugify", specifier = "==8.0.4" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "trafilatura", specifier = "==1.12.2" },


### PR DESCRIPTION
- Consolidates local setup into one uv-first path in `README.md`.
- Keeps setup provider-agnostic and removes workflow-specific noise.
- Improves onboarding consistency without changing runtime behavior.