### PR TITLE
fix: reliable commit-and-delivery

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,8 +1,8 @@
 # .github/ and scripts/
 
-Last-Reviewed-Date: 2026-04-07
-Last-Reviewed-Commit: 4853f3d
-Review-Note: Replay queue rewrites are atomic and malformed pending filenames are skipped without aborting recovery.
+Last-Reviewed-Date: 2026-05-31
+Last-Reviewed-Commit: d2177d2
+Review-Note: Added scripts/commit_strategy.py entrypoint that wraps workflow_commit_strategy.decide_commit_mode for CI use, supporting skip/create/amend modes.
 
 - `ci.yml`: runs `unittest discover` on push/PR. Python 3.11 + uv. No secrets needed.
 - `digest.yml`: daily 7am UTC cron + manual trigger. Validates Telegram creds, runs pipeline via `uv run python -m src`, extracts outputs in a separate module step, and treats telemetry/history failures as non-blocking while skipping empty-day commits.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,8 +1,8 @@
 # .github/ and scripts/
 
 Last-Reviewed-Date: 2026-05-31
-Last-Reviewed-Commit: d2177d2
-Review-Note: Added scripts/commit_strategy.py entrypoint that wraps workflow_commit_strategy.decide_commit_mode for CI use, supporting skip/create/amend modes.
+Last-Reviewed-Commit: 09f542d
+Review-Note: digest.yml now uses scripts/commit_strategy.py to decide skip/create/amend, enabling same-day re-run amend instead of duplicate commits.
 
 - `ci.yml`: runs `unittest discover` on push/PR. Python 3.11 + uv. No secrets needed.
 - `digest.yml`: daily 7am UTC cron + manual trigger. Validates Telegram creds, runs pipeline via `uv run python -m src`, extracts outputs in a separate module step, and treats telemetry/history failures as non-blocking while skipping empty-day commits.

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -93,26 +93,29 @@ jobs:
         run: |
           set -euo pipefail
 
-          PROCESSED_URLS="$(uv run python -m scripts.extract_processed_urls /tmp/pipeline.log)"
-          if [ "${PROCESSED_URLS}" = "0" ]; then
-            echo "No processed URLs; skipping commit/push for empty day"
-            echo "commit_status=skipped_empty_day" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add state.json data/
+
+          COMMIT_MODE="$(uv run python -m scripts.commit_strategy /tmp/pipeline.log)"
+          echo "Commit mode: ${COMMIT_MODE}"
+
+          if [ "${COMMIT_MODE}" = "skip" ]; then
+            echo "Skipping commit (no processed URLs or no staged changes)"
+            echo "commit_status=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${COMMIT_MODE}" = "amend" ]; then
+            git commit --amend --no-edit
+            git push --force-with-lease
+            echo "commit_status=amended" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           TODAY_UTC=$(date -u +%F)
           DAILY_SUBJECT="chore(digest): ${TODAY_UTC} daily digest"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add state.json data/
-          if git diff --staged --quiet; then
-            echo "No staged output changes; skipping commit/push"
-            echo "commit_status=no_changes" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           git commit -m "$DAILY_SUBJECT"
           git push
           echo "commit_status=pushed" >> "$GITHUB_OUTPUT"

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,194 @@
+# Architecture
+
+**Analysis Date:** 2026-05-31
+
+## Pattern Overview
+
+**Overall:** Serverless batch pipeline (cron-triggered, ephemeral execution)
+
+**Key Characteristics:**
+- Single-pass batch processing: poll → fetch → summarize → digest → send
+- Filesystem-as-database: all state and output is Markdown/JSON files committed to Git
+- No persistent server: runs exclusively as GitHub Actions workflow
+- Failure isolation: one bad URL never stops the run; failures recorded as first-class artifacts
+- Dual-backend summarization with concurrent thread pools (OpenRouter for articles, NotebookLM for YouTube + article fallback)
+
+## Layers
+
+**Orchestration Layer:**
+- Purpose: Coordinates the pipeline stages, manages timing, emits telemetry
+- Location: `src/main.py`
+- Contains: `run_pipeline()`, `main()`, `_run_pipeline_with_context()`
+- Depends on: All pipeline stage modules
+- Used by: `src/__main__.py` (entry point), GitHub Actions workflow
+
+**Ingestion Layer:**
+- Purpose: Polls Telegram for new URLs, manages offset state
+- Location: `src/telegram_client.py`
+- Contains: `poll_urls()`, `poll_urls_from_env()`, `extract_urls()`, `load_offset()`, `save_offset()`
+- Depends on: `src/_config.py` (TelegramConfig)
+- Used by: `src/main.py`
+
+**Content Fetching Layer:**
+- Purpose: Retrieves article text from URLs, classifies URL types, handles PDFs
+- Location: `src/content_fetcher.py`
+- Contains: `fetch_urls()`, `fetch_url()`, `fetch_article_text()`, URL classification re-exports
+- Depends on: `src/_url_utils.py`, `src/_failures.py`, `src/_prompts.py`, `trafilatura`, `pypdf`, `requests`
+- Used by: `src/main.py`
+
+**Summarization Layer:**
+- Purpose: Generates summaries using LLM backends with retry, concurrency, and fallback
+- Location: `src/summarizer.py` (orchestrator), `src/summarization/` (backends)
+- Contains:
+  - `src/summarizer.py`: `summarize_items()` — batch orchestrator with thread pools
+  - `src/summarization/common.py`: `Summarizer` protocol, `summarize_item()`, shared helpers
+  - `src/summarization/openrouter_backend.py`: `OpenRouterSummarizer` — free-model discovery, retry with backoff
+  - `src/summarization/notebooklm_backend.py`: `summarize_url()`, `summarize_youtube()` — async NotebookLM client
+- Depends on: `src/_config.py`, `src/_failures.py`, `src/_prompts.py`, `src/_url_utils.py`
+- Used by: `src/main.py`
+
+**Digest Assembly Layer:**
+- Purpose: Renders Markdown digest from summary results using prompt template
+- Location: `src/digest_generator.py`
+- Contains: `generate_digest()`, `_render_digest()`
+- Depends on: `src/_prompts.py` (digest template)
+- Used by: `src/main.py`
+
+**Delivery Layer:**
+- Purpose: Sends digest to Telegram as chunked HTML messages
+- Location: `src/telegram_client.py` (delivery functions)
+- Contains: `send_digest()`, `send_digest_from_env()`, `chunk_text_by_paragraph()`, HTML formatting
+- Depends on: `src/_config.py` (TelegramConfig), `requests`
+- Used by: `src/main.py`
+
+**Telemetry Layer:**
+- Purpose: Structured metrics emission, log parsing, run history reporting
+- Location: `src/telemetry/`
+- Contains:
+  - `src/telemetry/run_metrics.py`: `RunMetrics` dataclass, `build_run_metrics()`, `to_log_line()`
+  - `src/telemetry/pipeline_log_parser.py`: `extract_pipeline_outputs()` — parses stdout for CI
+  - `src/telemetry/run_history/`: GitHub Actions log fetching, metrics parsing, Markdown report rendering
+- Depends on: Nothing in the pipeline core (pure parsing/rendering)
+- Used by: `src/main.py` (emission), `scripts/` (CI consumption)
+
+**Internal Utilities (underscore-prefixed):**
+- Purpose: Shared primitives used across layers
+- Location: `src/_config.py`, `src/_types.py`, `src/_failures.py`, `src/_prompts.py`, `src/_url_utils.py`
+- Contains: Config dataclasses, TypedDict contracts, failure recording, prompt loading, URL utilities
+- Depends on: Standard library + `python-slugify`
+- Used by: All pipeline layers
+
+## Data Flow
+
+**Daily Digest Pipeline:**
+
+1. `poll_urls_from_env()` reads `state.json` for Telegram offset, calls `getUpdates` API, extracts URLs, saves new offset
+2. `fetch_urls()` iterates URLs: classifies each as `article` or `youtube`, fetches article text via HTTP (trafilatura for HTML, pypdf for PDFs), returns `FetchResult` dicts
+3. `summarize_items()` partitions work into article pool (OpenRouter) and YouTube/fallback pool (NotebookLM), runs concurrent `ThreadPoolExecutor` pools (max 3 workers each, 600s timeout per item), writes summaries to `data/sources/YYYY-MM-DD/slug.md`
+4. `generate_digest()` reads summary files, renders Markdown digest using `prompts/digest.txt` template, writes to `data/digests/YYYY-MM-DD.md`
+5. `send_digest_from_env()` splits digest into sections, converts Markdown to HTML, chunks to 4096 chars, sends via Telegram `sendMessage` API
+6. `build_run_metrics()` + `to_log_line()` emit structured `run_metrics:` JSON line to stdout for CI parsing
+
+**State Management:**
+- `state.json`: Single-field JSON (`{"telegram_offset": N}`), committed to repo, updated each run
+- `data/sources/YYYY-MM-DD/slug.md`: Individual summary files per URL per day
+- `data/digests/YYYY-MM-DD.md`: Assembled daily digest
+- `data/failed/YYYY-MM-DD/slug.md`: Failure records with URL, error, reason, timestamp
+- `data/cache/openrouter_models.json`: TTL-cached free model list (6h default)
+- `data/replay/notebooklm/pending/`: JSONL replay queue for NotebookLM failures
+
+**Failure Flow:**
+- Fetch failure → `write_failure_record()` writes to `data/failed/` → item passes through to summarizer with `status: "failed"`
+- Article fetch failure + NotebookLM fallback enabled → `summarize_failed_article_item()` retries via NotebookLM URL summarization
+- Summarization failure → `write_failure_record()` → item included in digest with error info
+- Timeout → `_timeout_result()` with `reason: "summarization_timeout"`
+
+## Key Abstractions
+
+**TypedDict Contracts (`src/_types.py`):**
+- Purpose: Define inter-module data flow shapes without runtime overhead
+- Examples: `FetchResult`, `SummaryResult`, `DigestResult`, `PollResult`, `PipelineOutcome`
+- Pattern: `TypedDict` with `total=False` for optional fields; status field discriminates outcomes (`"ok"`, `"failed"`, `"ignored"`)
+
+**Summarizer Protocol (`src/summarization/common.py`):**
+- Purpose: Backend-agnostic summarization contract
+- Examples: `Summarizer` protocol with `summarize_article()`, `summarize_article_from_url()`, `summarize_youtube()`
+- Pattern: Protocol class; `_PipelineSummarizer` and `_NoopSummarizer` implement it
+
+**Config Dataclasses (`src/_config.py`):**
+- Purpose: Centralized, typed environment variable reading
+- Examples: `OpenRouterConfig`, `NotebookLMConfig`, `TelegramConfig` — all `@dataclass(frozen=True)`
+- Pattern: `*_from_env()` factory functions read `os.environ`, validate, return frozen dataclass
+
+**Failure Reason Constants (`src/_failures.py`):**
+- Purpose: Categorized failure types for routing and fallback decisions
+- Examples: `HTTP_BLOCKED`, `TLS_ERROR`, `NETWORK_ERROR`, `ARTICLE_EXTRACT_TOO_SHORT`, `PDF_EXTRACT_FAILED`
+- Pattern: String constants + `write_failure_record()` for artifact creation
+
+**Commit Strategy (`src/workflow_commit_strategy.py`):**
+- Purpose: Pure logic for deciding git commit mode (skip/create/amend)
+- Examples: `decide_commit_mode()`, `daily_commit_message()`
+- Pattern: Pure functions, no subprocess calls; consumed by workflow shell script
+
+## Entry Points
+
+**Pipeline Entry Point:**
+- Location: `src/__main__.py` → `src/main.py:main()`
+- Triggers: `uv run python -m src` (GitHub Actions digest workflow)
+- Responsibilities: Runs full pipeline, emits `run_outcome:` and `run_metrics:` JSON lines to stdout
+
+**CI Script Entry Points:**
+- Location: `scripts/extract_pipeline_outputs.py`
+- Triggers: `uv run python -m scripts.extract_pipeline_outputs /tmp/pipeline.log`
+- Responsibilities: Parses pipeline stdout, writes GitHub Actions output variables
+
+- Location: `scripts/extract_processed_urls.py`
+- Triggers: `uv run python -m scripts.extract_processed_urls /tmp/pipeline.log`
+- Responsibilities: Extracts processed URL count from `run_outcome:` line for commit gate
+
+- Location: `scripts/write_run_history_summary.py`
+- Triggers: `uv run python -m scripts.write_run_history_summary`
+- Responsibilities: Fetches past workflow run logs, renders performance summary table to GitHub Step Summary
+
+- Location: `scripts/validate_claude_sync.py`
+- Triggers: Pre-commit hook (`.githooks/pre-commit`)
+- Responsibilities: Validates child CLAUDE.md documents are co-staged with routed code changes
+
+**Workflow Entry Points:**
+- Location: `.github/workflows/digest.yml`
+- Triggers: Daily cron (`0 7 * * *`), manual `workflow_dispatch`
+- Responsibilities: Full pipeline execution, output persistence, telemetry
+
+- Location: `.github/workflows/ci.yml`
+- Triggers: Push to `main`, pull requests
+- Responsibilities: Unit test execution via `unittest discover`
+
+- Location: `.github/workflows/opencode.yml`
+- Triggers: Issue/PR comments containing `/oc` or `/opencode`
+- Responsibilities: AI-assisted code review via opencode
+
+## Error Handling
+
+**Strategy:** Failure isolation with explicit artifact recording. One bad item never stops the batch.
+
+**Patterns:**
+- Fetch errors: Caught broadly (`except Exception`), classified by `_classify_fetch_error()` into reason constants, written to `data/failed/YYYY-MM-DD/slug.md`
+- Summarization errors: Caught broadly, written to failure records, item included in digest with error info
+- Timeout: `FutureTimeoutError` from `ThreadPoolExecutor`, produces `_timeout_result()` with `reason: "summarization_timeout"`
+- NotebookLM auth: `AuthError` mapped to `NOTEBOOKLM_AUTH_EXPIRED` reason, propagated as typed `NotebookLMSummaryError`/`YouTubeSummaryError`
+- Config errors: Missing env vars raise `RuntimeError` with descriptive message at pipeline start (fail-fast for configuration)
+- Telemetry errors: Non-blocking; `continue-on-error: true` in workflow, failures logged but don't block pipeline
+
+## Cross-Cutting Concerns
+
+**Logging:** `print()` for pipeline stage output (consumed by CI log parsing); `logging.getLogger(__name__)` for internal diagnostics in summarization and NotebookLM modules
+
+**Validation:** URL classification via `classify_url()` (hostname matching); content length checks (`< 200` chars = extraction failure); Telegram message filtering by `allowed_chat_id`
+
+**Authentication:** All credentials from environment variables via `src/_config.py` factories; NotebookLM storage state from `NOTEBOOKLM_STORAGE_STATE` env var or file path; Telegram bot token and chat ID from `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`; OpenRouter API key from `OPENROUTER_API_KEY`
+
+**Concurrency:** Dual `ThreadPoolExecutor` pools in `src/summarizer.py` — separate pools for OpenRouter (articles) and NotebookLM (YouTube + fallback), each capped at `_MAX_BACKEND_CONCURRENCY=3`. Rate-limit spacing via `_spacing_lock` in OpenRouter backend. 600s per-item timeout.
+
+---
+
+*Architecture analysis: 2026-05-31*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,184 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-05-31
+
+## Tech Debt
+
+**Duplicated `_extract_payload` function:**
+- Issue: `scripts/extract_processed_urls.py` (lines 9-22) contains an exact copy of `_extract_payload` from `src/telemetry/pipeline_log_parser.py` (lines 7-20). The script was intentionally decoupled from `src/` imports to avoid coupling the commit gate to the metrics parser, but this creates a maintenance burden.
+- Files: `scripts/extract_processed_urls.py`, `src/telemetry/pipeline_log_parser.py`
+- Impact: If the payload extraction logic changes (e.g., handling multiple matching lines, adding validation), both copies must be updated in lockstep. Drift between the two silently breaks the commit gate or telemetry.
+- Fix approach: Extract a shared `src/telemetry/_log_parsing.py` module with the `_extract_payload` helper. Both `pipeline_log_parser.py` and `scripts/extract_processed_urls.py` import from it. The script can import from `src/` since it already runs via `uv run`.
+
+**`workflow_commit_strategy.py` unused by workflow:**
+- Issue: `src/workflow_commit_strategy.py` defines `decide_commit_mode()` and `daily_commit_message()` with full test coverage (`tests/test_workflow_commit_strategy.py`), but `.github/workflows/digest.yml` (lines 87-112) implements the commit logic entirely in inline bash. The Python module is dead code in production.
+- Files: `src/workflow_commit_strategy.py`, `tests/test_workflow_commit_strategy.py`, `.github/workflows/digest.yml`
+- Impact: The tested Python logic and the actual bash implementation can diverge. The bash script doesn't implement the "amend" mode that `decide_commit_mode` supports.
+- Fix approach: Either wire the workflow to call `workflow_commit_strategy.py` via a script entrypoint, or remove the module and its tests if the bash approach is the intended final design.
+
+**Inconsistent type hint style (`Optional` vs `| None`):**
+- Issue: `src/telemetry/run_metrics.py` and `src/telemetry/run_history/models.py` use `Optional[float]` from `typing`, while the rest of the codebase uses modern `X | None` syntax via `from __future__ import annotations`.
+- Files: `src/telemetry/run_metrics.py` (lines 6, 19, 40), `src/telemetry/run_history/models.py` (lines 4, 13-16)
+- Impact: Inconsistent style. Minor readability issue.
+- Fix approach: Add `from __future__ import annotations` to both files and replace `Optional[X]` with `X | None`.
+
+**Stale `.claude/worktrees/` directories:**
+- Issue: Two Claude worktrees (`unruffled-blackwell`, `unruffled-poincare`) exist under `.claude/worktrees/` with full copies of the source tree. These are untracked but consume disk space and appear in glob/search results.
+- Files: `.claude/worktrees/unruffled-blackwell/`, `.claude/worktrees/unruffled-poincare/`
+- Impact: Confusing for developers and AI tools. Glob results include worktree files alongside main source files. Worktrees may contain divergent code from abandoned branches.
+- Fix approach: Clean up stale worktrees with `claude worktree remove` or manual deletion. Add `.claude/worktrees/` to `.gitignore` if not already covered.
+
+**Missing `.gitignore` file:**
+- Issue: The repository has no `.gitignore` file. Untracked files (`.claude/worktrees/`, `.opencode/package-lock.json`, `.planning/codebase/`, `data/replay/`) show up in `git status` output.
+- Files: project root
+- Impact: Risk of accidentally committing worktree artifacts, lock files, planning documents, or replay queue data. `git status` output is noisy.
+- Fix approach: Add a `.gitignore` covering at minimum: `.claude/worktrees/`, `.opencode/`, `.planning/`, `data/replay/`, `__pycache__/`, `*.pyc`, `.env*`.
+
+## Known Bugs
+
+**No URL deduplication in pipeline:**
+- Symptoms: If the same URL is sent to the Telegram bot multiple times (e.g., user re-shares), it is fetched, summarized, and included in the digest multiple times.
+- Files: `src/main.py` (line 46), `src/content_fetcher.py` (`fetch_urls`)
+- Trigger: Send the same URL twice before the next digest run.
+- Workaround: Manually avoid re-sending URLs. No automated dedup exists.
+
+**`digest.yml` commit step always creates new commits (no amend):**
+- Symptoms: The bash commit logic in `.github/workflows/digest.yml` (line 110) always runs `git commit -m "$DAILY_SUBJECT"` followed by `git push`. It never amends a previous same-day commit, even though `src/workflow_commit_strategy.py` supports an "amend" mode.
+- Files: `.github/workflows/digest.yml` (lines 87-112)
+- Trigger: Re-run the digest workflow on the same day (e.g., via `workflow_dispatch`). Creates a second commit with the same subject instead of amending.
+- Workaround: None. Duplicate same-day commits accumulate in git history.
+
+## Security Considerations
+
+**NotebookLM storage state contains auth cookies:**
+- Risk: `NOTEBOOKLM_STORAGE_STATE` secret contains browser session cookies (JSON with cookies array). These are passed as environment variables and written to temporary files during execution.
+- Files: `src/summarization/notebooklm_backend.py` (lines 76-111), `.github/workflows/digest.yml` (line 36)
+- Current mitigation: Temp files are created with `0o600` permissions and cleaned up after use. The secret is stored in GitHub Actions secrets.
+- Recommendations: The temp file cleanup in the `finally` block is correct. Consider adding a TTL check or warning when the storage state is older than N days to catch expired sessions early rather than failing mid-pipeline.
+
+**Hardcoded User-Agent string will become stale:**
+- Risk: `src/content_fetcher.py` (lines 65-73) hardcodes a Chrome 136 User-Agent. As Chrome versions advance, sites may start blocking this outdated UA string.
+- Files: `src/content_fetcher.py`
+- Current mitigation: None. The UA is static.
+- Recommendations: Either update the UA string periodically, or use a library like `fake-useragent` to rotate realistic UAs. Alternatively, make the UA configurable via environment variable.
+
+**No input validation on Telegram message content:**
+- Risk: URLs extracted from Telegram messages are passed directly to `requests.get()` for fetching. While `requests` handles most URL schemes safely, there is no validation against SSRF (e.g., `http://169.254.169.254/latest/meta-data/` on cloud instances, `file:///etc/passwd`).
+- Files: `src/telegram_client.py` (`extract_urls`), `src/content_fetcher.py` (`fetch_article_text`)
+- Current mitigation: The `requests` library does not follow `file://` scheme. GitHub Actions runners are ephemeral, limiting SSRF impact.
+- Recommendations: Add URL scheme validation (allow only `http` and `https`) in `extract_urls()` or `fetch_url()`. Block private IP ranges if running on infrastructure with internal services.
+
+## Performance Bottlenecks
+
+**Sequential URL fetching:**
+- Problem: `fetch_urls()` in `src/content_fetcher.py` (lines 172-176) fetches articles one at a time in a loop. Each fetch has a 30-second timeout.
+- Files: `src/content_fetcher.py` (lines 172-176)
+- Cause: Simple sequential loop with no concurrency. Summarization has ThreadPoolExecutor concurrency, but fetching does not.
+- Improvement path: Add a ThreadPoolExecutor for fetching, similar to the summarization concurrency pattern. Cap at 3-5 concurrent fetches to avoid overwhelming target sites. This would reduce total pipeline time for batches with many URLs.
+
+**NotebookLM backend creates new event loop per call:**
+- Problem: `summarize_url()` in `src/summarization/notebooklm_backend.py` (line 115) calls `asyncio.run()` which creates and destroys a new event loop for each invocation. When called from ThreadPoolExecutor workers, each thread gets its own loop.
+- Files: `src/summarization/notebooklm_backend.py` (line 115)
+- Cause: The NotebookLM client library is async, but the pipeline is synchronous. `asyncio.run()` is the bridge.
+- Improvement path: This works correctly for the current concurrency level (max 3). If concurrency increases, consider running a single event loop in a dedicated thread and dispatching work to it. Not urgent at current scale.
+
+**Run history downloads all workflow run logs:**
+- Problem: `fetch_history_snapshots()` in `src/telemetry/run_history/report.py` (lines 94-135) downloads the full logs zip for each historical run to extract a single `run_metrics:` line. For 7 runs, this means 7 zip downloads.
+- Files: `src/telemetry/run_history/report.py` (lines 94-135), `src/telemetry/run_history/github_client.py`
+- Cause: GitHub Actions API doesn't expose individual log lines; only full zip downloads.
+- Improvement path: Cache downloaded metrics by run_id to avoid re-downloading on subsequent runs. Or store metrics in a lightweight artifact (e.g., a JSON file committed to the repo) instead of parsing logs.
+
+## Fragile Areas
+
+**NotebookLM authentication lifecycle:**
+- Files: `src/summarization/notebooklm_backend.py` (lines 75-111)
+- Why fragile: The NotebookLM backend depends on browser session cookies stored in `NOTEBOOKLM_STORAGE_STATE`. These cookies expire unpredictably. When they expire, all YouTube summarization and article fallback fails with `notebooklm_auth_expired`. There is no automated way to refresh the session from CI.
+- Safe modification: Changes to `_resolve_storage_path()` must preserve the three-source priority (explicit path > state env var > default home path) and the temp file cleanup contract.
+- Test coverage: `tests/test_youtube_summarizer.py` covers storage path resolution and auth error mapping. Does not cover cookie refresh scenarios.
+
+**OpenRouter free model availability:**
+- Files: `src/summarization/openrouter_backend.py` (lines 99-168, 269-296)
+- Why fragile: The pipeline depends on free models from OpenRouter. Model availability changes without notice. The `_model_quality_score` heuristic (lines 122-135) uses hardcoded model name preferences that become stale as new models are released. If all free models are unavailable or rate-limited, article summarization fails entirely.
+- Safe modification: When updating `_model_quality_score`, preserve the tuple return format `(heuristic, context_length)` used for sorting. When changing `_is_free_openrouter_model`, ensure both `:free` suffix and zero-pricing checks remain.
+- Test coverage: `tests/test_summarizer.py` covers model ordering and quality scoring. Does not cover model API response format changes.
+
+**Telegram offset state in git:**
+- Files: `state.json`, `src/telegram_client.py` (lines 23-37)
+- Why fragile: The Telegram polling offset is stored in `state.json` which is committed to git after each run. If a commit fails to push (e.g., force push, branch protection), the offset is lost and the next run re-processes old messages, creating duplicate digests.
+- Safe modification: Changes to `load_offset`/`save_offset` must preserve the JSON format `{"telegram_offset": int}`. The file must be readable even if partially written.
+- Test coverage: `tests/test_telegram_client.py` covers round-trip state persistence and offset advancement.
+
+**Digest template variable replacement:**
+- Files: `src/digest_generator.py` (lines 52-58)
+- Why fragile: The digest uses simple string `.replace()` for template variables (`{{date}}`, `{{summaries}}`, etc.). If a summary itself contains `{{` text, it could be incorrectly replaced. The template variables are not namespaced or escaped.
+- Safe modification: When adding new template variables, ensure they don't collide with content that summaries might contain. Always add the variable to both the prompt template and the replacement chain.
+- Test coverage: `tests/test_digest_generator.py` covers basic template rendering and failure section inclusion.
+
+## Scaling Limits
+
+**GitHub Actions 6-hour job timeout:**
+- Current capacity: Digest workflow has a 20-minute timeout (`.github/workflows/digest.yml` line 24). Each summarization item has a 600-second (10-minute) timeout.
+- Limit: With sequential fetching and 10-minute per-item summarization, a batch of ~10 URLs could approach the 20-minute workflow timeout if several items are slow.
+- Scaling path: Add concurrent fetching (see Performance Bottlenecks). Increase workflow timeout if batch sizes grow. Consider splitting into fetch and summarize jobs.
+
+**Telegram message size limit:**
+- Current capacity: Messages are chunked at 4096 characters (`src/telegram_client.py` line 161).
+- Limit: Telegram API has a hard 4096-character limit per message. Very long digests with many items produce many chunks, which may hit Telegram's rate limit (~30 messages/second to same chat).
+- Scaling path: Current paragraph-based chunking handles this well. If digests grow very large, consider summarizing fewer items or truncating individual summaries.
+
+**Git repository growth from daily commits:**
+- Current capacity: One commit per day with digest artifacts (markdown files, failure records, source summaries).
+- Limit: Over months, the `data/` directory grows with daily subdirectories. Each failed URL creates a markdown file. The repo accumulates history that is never cleaned.
+- Scaling path: Periodically archive old `data/` entries. Consider storing digests in a separate branch or external storage. Add `.gitignore` rules for `data/cache/` to avoid committing model cache.
+
+## Dependencies at Risk
+
+**`notebooklm-py==0.3.4`:**
+- Risk: This is a niche, unofficial Python package that wraps NotebookLM's browser-based API using Playwright. It may break without notice if Google changes the NotebookLM UI. The pinned version `0.3.4` may not receive updates.
+- Impact: YouTube summarization and article fallback summarization would fail entirely. The pipeline would still work for articles via OpenRouter.
+- Migration plan: Monitor the package for updates. If abandoned, consider alternative YouTube summarization approaches (e.g., youtube-transcript-api + LLM summarization, or Gemini's native YouTube understanding).
+
+**`trafilatura==1.12.2`:**
+- Risk: Trafilatura is the primary HTML-to-text extraction library. Major version updates may change extraction behavior or API. The fallback class in `src/content_fetcher.py` (lines 14-19) handles import failure gracefully.
+- Impact: Article text extraction quality could degrade with library updates, or the library could become unmaintained.
+- Migration plan: The `try/except ImportError` pattern already provides a graceful degradation path. Alternative libraries include `readability-lxml`, `newspaper3k`, or `beautifulsoup4`.
+
+## Missing Critical Features
+
+**No URL deduplication:**
+- Problem: The pipeline does not check whether a URL has already been processed in a previous run. Re-sent URLs are re-fetched and re-summarized.
+- Blocks: Efficient handling of re-shared URLs. Prevents duplicate entries in digests.
+
+**No digest delivery retry:**
+- Problem: If Telegram `sendMessage` fails (network error, rate limit), the digest is lost. There is no retry mechanism for delivery.
+- Blocks: Reliable digest delivery. A transient Telegram outage means the day's digest is never delivered.
+
+## Test Coverage Gaps
+
+**No integration test for full pipeline with real-ish data:**
+- What's not tested: The end-to-end flow from `main()` through all modules with realistic data volumes and timing. All tests mock at module boundaries.
+- Files: `tests/test_main.py`
+- Risk: Integration issues between modules (e.g., dict key mismatches, type coercion bugs) could go unnoticed until production.
+- Priority: Medium
+
+**No test for `fetch_urls` with concurrent or rate-limited responses:**
+- What's not tested: How `fetch_urls` behaves when target sites return 429 responses, slow responses, or when many URLs target the same domain.
+- Files: `tests/test_content_fetcher.py`, `src/content_fetcher.py`
+- Risk: Rate limiting from target sites could cause cascading failures in a batch. No backoff or delay between fetches exists.
+- Priority: Medium
+
+**No test for Telegram API retry or partial delivery failure:**
+- What's not tested: What happens when `send_digest` succeeds for some chunks but fails for others. The current code has no retry and no rollback.
+- Files: `tests/test_telegram_client.py`, `src/telegram_client.py`
+- Risk: Partial digest delivery (user receives first 2 chunks of a 5-chunk digest) with no indication of failure.
+- Priority: Low
+
+**No test for `_format_digest_line_as_html` edge cases:**
+- What's not tested: Nested markdown (bold inside links), malformed markdown, very long lines, Unicode edge cases in the HTML formatter.
+- Files: `src/telegram_client.py` (lines 222-251), `tests/test_telegram_client.py`
+- Risk: Malformed HTML sent to Telegram could cause rendering issues or API rejection.
+- Priority: Low
+
+---
+
+*Concerns audit: 2026-05-31*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,244 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-05-31
+
+## Naming Patterns
+
+**Files:**
+- `snake_case.py` for all Python modules
+- Underscore-prefixed files (`_types.py`, `_config.py`, `_failures.py`, `_prompts.py`, `_url_utils.py`) are internal/private modules — not entry points
+- Test files use `test_<module>.py` prefix, one test file per source module
+
+**Functions:**
+- `snake_case` for all functions and methods
+- Private helpers use leading underscore: `_extract_html_text()`, `_classify_fetch_error()`, `_split_digest_sections()`
+- Factory functions use `*_from_env` suffix: `openrouter_config_from_env()`, `telegram_config_from_env()`, `notebooklm_config_from_env()`
+- Public API functions are concise and verb-led: `fetch_url()`, `summarize_items()`, `generate_digest()`, `poll_urls()`, `send_digest()`
+
+**Variables:**
+- `snake_case` for all variables
+- Module-level constants use `UPPER_SNAKE_CASE`: `HTTP_BLOCKED`, `TLS_ERROR`, `REQUEST_HEADERS`, `YOUTUBE_HOSTS`, `_MAX_BACKEND_CONCURRENCY`, `_FUTURE_TIMEOUT_SECONDS`
+- Private module-level constants use `_UPPER_SNAKE_CASE`
+
+**Types/Classes:**
+- `PascalCase` for classes: `OpenRouterConfig`, `FetchProcessingError`, `OpenRouterSummarizer`
+- `PascalCase` for TypedDicts: `FetchResult`, `SummaryResult`, `DigestResult`, `PollResult`, `PipelineOutcome`
+- `PascalCase` for Protocols: `Summarizer`
+- Private classes use leading underscore: `_PipelineSummarizer`, `_NoopSummarizer`, `_RetryingSummarizerBase`
+- Custom exceptions suffix `Error`: `FetchProcessingError`, `YouTubeSummaryError`, `NotebookLMSummaryError`, `SourceAddError`
+
+## Code Style
+
+**Formatting:**
+- No explicit formatter config (no `.prettierrc`, no `ruff.toml`, no `pyproject.toml` tool sections for formatting)
+- Consistent 4-space indentation throughout
+- Line length appears to target ~120 characters (no hard enforcement)
+- String concatenation uses `+` operator for simple cases, f-strings for interpolation
+
+**Linting:**
+- No linter config file detected (no `.eslintrc`, `ruff.toml`, `pyproject.toml [tool.ruff]`)
+- `# noqa: BLE001` used to suppress broad-exception warnings where intentional
+- `# noqa: E402` used after try/except import blocks where import order is affected
+
+**Type Annotations:**
+- All modules begin with `from __future__ import annotations` to enable modern syntax
+- Use `X | None` instead of `Optional[X]` (except `Optional` still used in `src/telemetry/run_metrics.py` and `src/telemetry/run_history/` — legacy pattern)
+- Use `dict[str, Any]`, `list[str]` — lowercase generic containers
+- TypedDict for inter-module data contracts (not dataclasses for pipeline data flow)
+- `@dataclass(frozen=True)` for configuration objects: `OpenRouterConfig`, `NotebookLMConfig`, `TelegramConfig`, `RunMetrics`, `RunHistorySnapshot`
+- `Protocol` for structural typing: `Summarizer` protocol in `src/summarization/common.py`
+- `Literal` for constrained string types: `CommitMode = Literal["skip", "create", "amend"]`
+- Return type annotations on all public and private functions
+
+## Import Organization
+
+**Order:**
+1. `from __future__ import annotations` (always first)
+2. Standard library imports (alphabetical)
+3. Third-party imports (`requests`, `trafilatura`, `slugify`)
+4. Internal `src.*` imports
+
+**Pattern:**
+```python
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from src._types import PipelineOutcome
+from src.content_fetcher import fetch_urls
+```
+
+**Path Aliases:**
+- None. All imports use absolute `from src.X import Y` paths.
+- No relative imports except within `src/telemetry/run_history/` package (uses `from .github_client import ...`)
+
+**Import rules:**
+- All `src/` imports use `from src.X import Y` — never `import src.X`
+- Optional dependencies use try/except with fallback stubs (see `src/content_fetcher.py` for `trafilatura` and `pypdf`, `src/summarization/notebooklm_backend.py` for `notebooklm`)
+
+## Error Handling
+
+**Strategy: Failure isolation — one bad item must not stop the pipeline run.**
+
+**Patterns:**
+
+1. **Status dict contract** — Functions return `dict[str, Any]` with `"status": "ok" | "failed" | "ignored"`, never raise on expected failures:
+```python
+# From src/content_fetcher.py
+def fetch_url(url: str, failed_base_dir: str = "data/failed") -> dict[str, Any]:
+    try:
+        content = fetch_article_text(url)
+    except Exception as exc:  # noqa: BLE001
+        reason = _classify_fetch_error(exc)
+        failure_path = write_failure_record(...)
+        return {"status": "failed", "kind": "article", "url": url, "error": str(exc), ...}
+    return {"status": "ok", "kind": "article", "url": url, "content": content}
+```
+
+2. **Failure record files** — All failures write a Markdown failure record via `write_failure_record()` in `src/_failures.py` to `data/failed/<date>/<slug>.md`.
+
+3. **Reason constants** — Failure reasons are string constants defined in `src/_failures.py` and `src/summarization/notebooklm_backend.py`:
+```python
+HTTP_BLOCKED = "http_blocked"
+TLS_ERROR = "tls_error"
+PDF_EXTRACT_FAILED = "pdf_extract_failed"
+NETWORK_ERROR = "network_error"
+YOUTUBE_AUTH_EXPIRED = "youtube_auth_expired"
+```
+
+4. **Typed error classes with `.reason`** — Custom exceptions carry a `.reason` attribute for classification:
+```python
+class FetchProcessingError(RuntimeError):
+    def __init__(self, reason: str, message: str) -> None:
+        self.reason = reason
+        super().__init__(message)
+```
+
+5. **Broad exception catching at boundaries** — `except Exception as exc:  # noqa: BLE001` at pipeline boundaries (fetch, summarize), with classification via `_classify_fetch_error()` or `getattr(exc, "reason", ...)`.
+
+6. **RuntimeError for configuration errors** — Missing env vars, missing prompt files raise `RuntimeError` with descriptive messages:
+```python
+raise RuntimeError("Missing OPENROUTER_API_KEY environment variable")
+raise RuntimeError("Missing prompt file: " + path)
+```
+
+## Logging
+
+**Framework:** `logging` module (stdlib)
+
+**Patterns:**
+- Logger per module: `LOGGER = logging.getLogger(__name__)`
+- Used in `src/summarizer.py` and `src/summarization/notebooklm_backend.py`
+- Structured key=value format for machine-parseable log lines:
+```python
+LOGGER.info(
+    "summarize_item kind=%s work_type=%s status=%s elapsed=%.2fs url=%s",
+    kind, work_type, status, elapsed, url,
+)
+```
+- `LOGGER.warning()` for non-fatal cleanup failures (e.g., notebook deletion after success)
+- `print()` used in `src/main.py` for pipeline progress output (consumed by CI log parser)
+- Structured stdout lines for CI parsing: `run_outcome:{json}`, `run_metrics:{json}`
+
+## Comments
+
+**When to comment:**
+- Minimal inline comments. Code is self-documenting through naming.
+- Comments explain "why" not "what" — e.g., `# noqa: BLE001` for intentional broad catches
+- Docstrings are rare — only `_override_env` in `tests/test_summarizer.py` has one
+
+**JSDoc/TSDoc:**
+- Not applicable (Python codebase). No docstring convention enforced.
+
+## Function Design
+
+**Size:** Functions are small and focused. Most are under 30 lines. The largest functions are in `src/summarizer.py` (`summarize_items` at ~170 lines) due to concurrency orchestration.
+
+**Parameters:**
+- Use keyword arguments for clarity at call sites
+- Default values for paths: `base_dir: str = "data/sources"`, `failed_base_dir: str = "data/failed"`
+- Configuration objects (`OpenRouterConfig`, `TelegramConfig`) passed as single params instead of many individual args
+- `@classmethod from_config()` factory pattern: `OpenRouterSummarizer.from_config(config)`
+
+**Return Values:**
+- Pipeline functions return `dict[str, Any]` status dicts (not dataclasses)
+- Pure functions return simple types: `str`, `list[str]`, `bool`
+- Config factories return frozen dataclasses
+- Telemetry uses frozen dataclass `RunMetrics` serialized to JSON
+
+## Module Design
+
+**Exports:**
+- `__all__` defined only in `src/content_fetcher.py` (public facade re-exporting from internal modules)
+- Other modules rely on conventional Python import visibility
+
+**Barrel Files:**
+- `src/content_fetcher.py` acts as a public facade, re-exporting from `_failures`, `_prompts`, `_url_utils` for backward compatibility
+- `src/__init__.py` is empty — no package-level exports
+
+**Internal module pattern:**
+- Underscore-prefixed modules (`_types.py`, `_config.py`, `_failures.py`, `_prompts.py`, `_url_utils.py`) are private implementation details
+- Import from them directly when building new internal code: `from src._failures import write_failure_record`
+- Public modules may re-export for backward compat
+
+**Subpackage pattern:**
+- `src/summarization/` — Backends isolated from orchestration. `common.py` defines `Summarizer` Protocol + shared helpers. Each backend (`openrouter_backend.py`, `notebooklm_backend.py`) implements the protocol independently.
+- `src/telemetry/` — Metrics, log parsing, and run history. `run_history/` is a sub-subpackage with clean separation: `models.py` (data), `parser.py` (parsing), `github_client.py` (network), `report.py` (rendering, pure).
+
+**No globals or hidden side effects:**
+- Functions return values. No module-level mutable state.
+- `__main__.py` is the single entry point: `from src.main import main; main()`
+
+## Data Contracts
+
+**TypedDict for pipeline data flow:**
+```python
+# src/_types.py
+class FetchResult(TypedDict, total=False):
+    status: str   # "ok" | "failed" | "ignored"
+    kind: str     # "article" | "youtube" | "unknown"
+    url: str
+    content: str  # present when status="ok" and kind="article"
+```
+
+**Status dict keys are the contract:**
+- `"status"`: always present — `"ok"`, `"failed"`, or `"ignored"`
+- `"kind"`: always present — `"article"`, `"youtube"`, or `"unknown"`
+- `"url"`: always present
+- `"error"`: present when `status="failed"`
+- `"failure_path"`: present when `status="failed"`
+- `"reason"`: present when `status="failed"` — classifies the failure type
+- `"summary_path"`: present when `status="ok"` for summarization results
+- `"content"`: present when `status="ok"` for fetch results (articles only)
+
+**Metric keys are the contract** — renaming or removing a key in `RunMetrics` breaks CI parsing. Add new keys, don't rename old ones.
+
+## Environment Configuration
+
+**Centralized env-var reading** in `src/_config.py`:
+- Each config domain has a frozen dataclass + `*_from_env()` factory
+- `OpenRouterConfig` / `openrouter_config_from_env()`
+- `NotebookLMConfig` / `notebooklm_config_from_env()`
+- `TelegramConfig` / `telegram_config_from_env()`
+- Boolean env vars parsed via `_env_enabled()` accepting `true/false/yes/no/on/off/1/0`
+
+## Concurrency Patterns
+
+**Thread pools with bounded concurrency:**
+- `ThreadPoolExecutor` with named threads: `thread_name_prefix="openrouter"` / `"notebooklm"`
+- Concurrency clamped via `_clamp_concurrency()` with env-var control and max cap
+- Per-future timeout with `_FUTURE_TIMEOUT_SECONDS = 600`
+- Order preservation via pre-allocated `results[idx]` list
+
+**Thread safety:**
+- `threading.Lock()` for shared mutable state (spacing enforcement, model cache init)
+- Double-checked locking for lazy initialization: `_models()` in `OpenRouterSummarizer`
+
+---
+
+*Convention analysis: 2026-05-31*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,183 @@
+# External Integrations
+
+**Analysis Date:** 2026-05-31
+
+## APIs & External Services
+
+**Telegram Bot API:**
+- Purpose: Input source (URL polling) and output delivery (digest messages)
+- SDK/Client: Raw HTTP via `requests` (no Telegram SDK)
+- Implementation: `src/telegram_client.py`
+- Endpoints used:
+  - `GET /bot{token}/getUpdates` - Poll for new messages with offset-based pagination
+  - `POST /bot{token}/sendMessage` - Deliver digest chunks (HTML parse mode, 4096 char limit)
+  - `GET /bot{token}/getMe` - Token validation (in CI workflow)
+  - `GET /bot{token}/deleteWebhook` - Clear webhook on startup (in CI workflow)
+- Auth: `TELEGRAM_BOT_TOKEN` (env var / GitHub secret)
+- Chat filtering: `TELEGRAM_CHAT_ID` (env var / GitHub secret, integer)
+- State: `state.json` stores `telegram_offset` for resumable polling
+
+**OpenRouter API:**
+- Purpose: LLM-based article summarization using free models
+- SDK/Client: Raw HTTP via `requests` (OpenAI-compatible chat completions format)
+- Implementation: `src/summarization/openrouter_backend.py`
+- Endpoints used:
+  - `GET /api/v1/models` - Model discovery (free models only, cached with TTL)
+  - `POST /api/v1/chat/completions` - Chat completion for summarization
+- Auth: `OPENROUTER_API_KEY` (env var / GitHub secret, Bearer token)
+- Base URL: `OPENROUTER_API_BASE` (default: `https://openrouter.ai/api/v1`)
+- Model selection: `OPENROUTER_PREFERRED_MODELS` (comma-separated, e.g., `google/gemma-3-27b-it:free,qwen/qwen3-32b:free,deepseek/deepseek-r1:free`)
+- Rate limiting: Configurable min spacing, exponential backoff with jitter, max retries
+- Model cache: `data/cache/openrouter_models.json` (TTL: 6 hours / 21600s by default)
+- Key config env vars:
+  - `OPENROUTER_MIN_SPACING_SECONDS` (default: 1)
+  - `OPENROUTER_MAX_RETRIES` (default: 6)
+  - `OPENROUTER_INITIAL_BACKOFF_SECONDS` (default: 5)
+  - `OPENROUTER_MAX_BACKOFF_SECONDS` (default: 120)
+  - `OPENROUTER_MODELS_CACHE_TTL_SECONDS` (default: 21600)
+
+**Google NotebookLM (via notebooklm-py):**
+- Purpose: YouTube video summarization and article fallback summarization
+- SDK/Client: `notebooklm-py` 0.3.4 (`notebooklm.NotebookLMClient`)
+- Implementation: `src/summarization/notebooklm_backend.py`
+- Workflow:
+  1. Create temporary notebook (`client.notebooks.create`)
+  2. Add URL as source (`client.sources.add_url`, with `wait=True`)
+  3. Ask summarization prompt (`client.chat.ask`)
+  4. Delete temporary notebook (`client.notebooks.delete`)
+- Auth: `NOTEBOOKLM_STORAGE_STATE` (env var / GitHub secret, JSON browser storage state)
+  - Alternative: `NOTEBOOKLM_STORAGE_PATH` (file path) or `~/.notebooklm/storage_state.json` (local default)
+- Async: Uses `asyncio.run()` to bridge sync pipeline with async SDK
+- Fallback: Articles failing fetch (HTTP_BLOCKED, NETWORK_ERROR, TLS_ERROR, etc.) retried via NotebookLM when `NOTEBOOKLM_ARTICLE_FALLBACK_ENABLED=true` (default: true)
+- Prompt files:
+  - `prompts/youtube_summarize.txt` - YouTube summarization
+  - `prompts/summarize.txt` - Article fallback summarization
+
+**GitHub Actions API:**
+- Purpose: Run history telemetry and performance reporting
+- SDK/Client: `urllib.request` (stdlib, no GitHub SDK)
+- Implementation: `src/telemetry/run_history/github_client.py`
+- Endpoints used:
+  - `GET /repos/{repo}/actions/workflows/{file}/runs` - List past workflow runs
+  - `GET /repos/{repo}/actions/runs/{id}/logs` - Download run logs (zip)
+- Auth: `GITHUB_TOKEN` (automatic workflow token, Bearer)
+- API version: `2022-11-28` (set via `X-GitHub-Api-Version` header)
+- Used by: `scripts/write_run_history_summary.py` to build performance summary table in job summary
+
+## Data Storage
+
+**Databases:**
+- None - No database. All state is file-based.
+
+**File-Based State:**
+- `state.json` - Telegram polling offset (`{"telegram_offset": int}`)
+- `data/digests/{date}.md` - Generated daily digest Markdown files
+- `data/sources/{date}/{slug}.md` - Individual summarization outputs
+- `data/failed/{date}/{slug}.md` - Failure records with URL, timestamp, reason, error
+- `data/cache/openrouter_models.json` - Cached OpenRouter free model list with TTL
+- `data/replay/` - Replay data directory
+
+**File Storage:**
+- Local filesystem only (ephemeral GitHub Actions runner)
+- Output artifacts committed back to repository via `git add state.json data/ && git commit && git push`
+
+**Caching:**
+- OpenRouter model list: JSON file cache at `data/cache/openrouter_models.json` with configurable TTL
+- uv dependency cache: GitHub Actions `astral-sh/setup-uv@v7` with `enable-cache: true`
+
+## Authentication & Identity
+
+**Auth Provider:**
+- Custom - No auth framework. All credentials are API keys/tokens passed via environment variables.
+
+**Credential Summary:**
+| Secret | Source | Used By |
+|--------|--------|---------|
+| `TELEGRAM_BOT_TOKEN` | GitHub secret | `src/telegram_client.py` |
+| `TELEGRAM_CHAT_ID` | GitHub secret | `src/telegram_client.py` |
+| `OPENROUTER_API_KEY` | GitHub secret | `src/summarization/openrouter_backend.py` |
+| `NOTEBOOKLM_STORAGE_STATE` | GitHub secret | `src/summarization/notebooklm_backend.py` |
+| `GITHUB_TOKEN` | Automatic (workflow) | `src/telemetry/run_history/github_client.py` |
+| `OPENCODE_API_KEY` | GitHub secret | `.github/workflows/opencode.yml` (opencode bot) |
+
+**Validation:**
+- Pipeline validates required secrets at startup via shell `test -n` in `digest.yml`
+- Config factories raise `RuntimeError` for missing required env vars (`src/_config.py`)
+- Telegram token validated via `getMe` API call before pipeline runs
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None - No external error tracking service
+
+**Logs:**
+- Structured stdout logging via Python `logging` module and `print()` statements
+- Two machine-readable log contracts emitted to stdout:
+  - `run_outcome:{JSON}` - Pipeline outcome dict (consumed by `scripts/extract_pipeline_outputs.py` and `scripts/extract_processed_urls.py`)
+  - `run_metrics:{JSON}` - Run metrics dataclass (consumed by `src/telemetry/pipeline_log_parser.py`)
+- Pipeline log captured to `/tmp/pipeline.log` in CI, uploaded as artifact on failure
+- Run history performance table written to `$GITHUB_STEP_SUMMARY` (visible in GitHub Actions UI)
+
+**Telemetry Modules:**
+- `src/telemetry/run_metrics.py` - `RunMetrics` frozen dataclass, `build_run_metrics()`, `to_log_line()`
+- `src/telemetry/pipeline_log_parser.py` - Parse `run_outcome:` and `run_metrics:` from log text
+- `src/telemetry/run_history/` - GitHub Actions log fetching, metrics parsing, Markdown report rendering
+
+## CI/CD & Deployment
+
+**Hosting:**
+- GitHub Actions (serverless, no persistent infrastructure)
+
+**CI Pipeline:**
+- `.github/workflows/ci.yml` - Unit tests on push/PR to `main`
+- `.github/workflows/digest.yml` - Daily digest pipeline (cron + manual)
+- `.github/workflows/opencode.yml` - AI code review bot triggered by `/oc` comments
+
+**Deployment Model:**
+- No deployment. Pipeline runs in CI, outputs committed back to repo.
+- Daily commit message format: `chore(digest): {YYYY-MM-DD} daily digest`
+- Commit strategy logic in `src/workflow_commit_strategy.py` (pure logic, decides skip/create/amend)
+- Empty-day commits skipped (no processed URLs = no commit)
+
+**Git Hooks:**
+- `.githooks/pre-commit` - Runs `scripts/validate_claude_sync.py` to enforce child `CLAUDE.md` co-staging with routed code changes
+
+## Environment Configuration
+
+**Required env vars (pipeline):**
+- `TELEGRAM_BOT_TOKEN` - Telegram bot authentication
+- `TELEGRAM_CHAT_ID` - Target chat for digest delivery
+- `OPENROUTER_API_KEY` - OpenRouter LLM API access
+- `NOTEBOOKLM_STORAGE_STATE` - NotebookLM browser storage state (JSON)
+
+**Optional env vars (pipeline):**
+- `OPENROUTER_API_BASE` - Override OpenRouter base URL
+- `OPENROUTER_PREFERRED_MODELS` - Comma-separated preferred model order
+- `OPENROUTER_MIN_SPACING_SECONDS` - Rate limit spacing
+- `OPENROUTER_MAX_RETRIES` - Retry count
+- `OPENROUTER_INITIAL_BACKOFF_SECONDS` - Initial backoff
+- `OPENROUTER_MAX_BACKOFF_SECONDS` - Max backoff cap
+- `OPENROUTER_MODELS_CACHE_PATH` - Model cache file path
+- `OPENROUTER_MODELS_CACHE_TTL_SECONDS` - Model cache TTL
+- `OPENROUTER_MAX_CONCURRENCY` - Thread pool size (default: 1, max: 3)
+- `NOTEBOOKLM_MAX_CONCURRENCY` - Thread pool size (default: 1, max: 3)
+- `NOTEBOOKLM_STORAGE_PATH` - File path alternative to storage state env var
+- `NOTEBOOKLM_SUMMARIZE_PROMPT_PATH` - YouTube prompt file path
+- `NOTEBOOKLM_ARTICLE_SUMMARIZE_PROMPT_PATH` - Article fallback prompt file path
+- `NOTEBOOKLM_ARTICLE_FALLBACK_ENABLED` - Enable/disable article fallback (default: true)
+
+**Secrets location:**
+- GitHub repository secrets (Settings > Secrets and variables > Actions)
+- No local `.env` files present or used
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None - No webhook endpoints. Telegram interaction is poll-based via `getUpdates`.
+
+**Outgoing:**
+- None - No outbound webhook calls. All external communication is request-response.
+
+---
+
+*Integration audit: 2026-05-31*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,99 @@
+# Technology Stack
+
+**Analysis Date:** 2026-05-31
+
+## Languages
+
+**Primary:**
+- Python 3.11 (pinned `>=3.11,<3.12`) - All application code, scripts, tests
+
+**Secondary:**
+- Shell (POSIX sh) - Git hooks (`.githooks/pre-commit`)
+- YAML - GitHub Actions workflow definitions (`.github/workflows/`)
+
+## Runtime
+
+**Environment:**
+- CPython 3.11 on `ubuntu-latest` (GitHub Actions runner)
+- Local development: macOS (darwin), Python 3.11 via uv
+
+**Package Manager:**
+- uv (Astral) - fast Python package installer and resolver
+- Lockfile: `uv.lock` (present, committed, version 1 / revision 3)
+- Install command: `uv sync --frozen`
+- Run command: `uv run python -m src` (pipeline), `uv run python -m unittest discover -s tests -p "test_*.py"` (tests)
+- Project is non-installable (`[tool.uv] package = false` in `pyproject.toml`)
+
+## Frameworks
+
+**Core:**
+- None - The application is a batch pipeline script with no web framework. It runs as a single-pass module invoked via `python -m src`.
+
+**Testing:**
+- `unittest` (Python stdlib) - Test runner and assertion library
+- Config: No config file; discovered via `python -m unittest discover -s tests -p "test_*.py"`
+
+**Build/Dev:**
+- uv - Dependency resolution, virtual environment management, script execution
+- GitHub Actions - CI/CD orchestration (no local build step)
+
+## Key Dependencies
+
+**Critical (declared in `pyproject.toml`):**
+- `requests` 2.32.5 - HTTP client for Telegram Bot API, OpenRouter API, and article fetching
+- `trafilatura` 1.12.2 - HTML-to-text extraction for article content
+- `notebooklm-py` 0.3.4 - Python SDK for Google NotebookLM (YouTube and fallback summarization)
+- `pypdf` 5.4.0 - PDF text extraction for PDF article URLs
+- `python-slugify` 8.0.4 - URL-to-slug conversion for output file naming
+- `lxml_html_clean` 0.4.4 - HTML sanitization dependency for trafilatura
+
+**Transitive (from `uv.lock`, notable):**
+- `anyio` 4.12.1 - Async I/O (used by notebooklm-py)
+- `certifi` 2026.2.25 - TLS certificate bundle (used by requests)
+- `charset-normalizer` 3.4.6 - Encoding detection (used by requests)
+- `click` 8.3.1 - CLI framework (used by notebooklm-py)
+- `babel` 2.18.0 - Internationalization (used by trafilatura)
+
+## Configuration
+
+**Environment:**
+- All configuration via environment variables, read centrally in `src/_config.py`
+- Three config dataclasses: `OpenRouterConfig`, `NotebookLMConfig`, `TelegramConfig`
+- Factory functions: `openrouter_config_from_env()`, `notebooklm_config_from_env()`, `telegram_config_from_env()`
+- No `.env` files used; secrets injected via GitHub Actions `secrets` context
+- Boolean env vars parsed by `_env_enabled()` accepting `0/false/no/off` and `1/true/yes/on`
+
+**Build:**
+- `pyproject.toml` - Project metadata and dependency declaration
+- `uv.lock` - Frozen dependency resolution
+- No `setup.py`, `setup.cfg`, or `Makefile`
+
+**Prompt Templates:**
+- `prompts/summarize.txt` - Article summarization system prompt (OpenRouter)
+- `prompts/youtube_summarize.txt` - YouTube summarization prompt (NotebookLM)
+- `prompts/digest.txt` - Digest assembly template with `{{placeholder}}` tokens
+
+## Platform Requirements
+
+**Development:**
+- Python 3.11 (`>=3.11,<3.12`)
+- uv package manager
+- Git with custom hooks path: `git config core.hooksPath .githooks`
+- Optional: local NotebookLM storage state at `~/.notebooklm/storage_state.json`
+
+**Production:**
+- GitHub Actions `ubuntu-latest` runner
+- 20-minute timeout per digest run
+- Daily cron at `0 7 * * *` (7:00 AM UTC)
+- Manual trigger via `workflow_dispatch`
+- No persistent server; fully ephemeral execution
+
+**CI:**
+- GitHub Actions `ubuntu-latest` runner
+- 10-minute timeout per CI run
+- Triggers on push to `main` and pull requests
+- Runs `unittest discover` only (no linting, no type checking)
+
+---
+
+*Stack analysis: 2026-05-31*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,254 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-05-31
+
+## Directory Layout
+
+```
+tldr-bot/
+├── src/                    # Pipeline source code (Python package)
+│   ├── summarization/      # LLM summarization backends
+│   └── telemetry/          # Metrics emission, log parsing, run history
+│       └── run_history/    # GitHub Actions run history reporting
+├── scripts/                # CI helper scripts (invoked as modules)
+├── tests/                  # Unit tests (unittest, mirrors src/ layout)
+├── prompts/                # LLM prompt templates (plain text)
+├── data/                   # Pipeline output artifacts (committed)
+│   ├── digests/            # Daily Markdown digests
+│   ├── sources/            # Per-URL summary files, organized by date
+│   ├── failed/             # Failure records, organized by date
+│   ├── cache/              # OpenRouter model cache
+│   └── replay/             # NotebookLM failure replay queue
+├── docs/                   # Project documentation and images
+├── .github/
+│   └── workflows/          # GitHub Actions workflow definitions
+├── .githooks/              # Git hooks (pre-commit)
+├── .planning/              # GSD planning artifacts
+├── .opencode/              # OpenCode configuration and GSD workflows
+├── CLAUDE.md               # Root AI routing manifest
+├── architecture.md         # Architecture design document (prose)
+├── pyproject.toml          # Python project metadata (uv)
+├── uv.lock                 # Dependency lockfile
+├── state.json              # Telegram polling offset (committed state)
+└── README.md               # Project overview
+```
+
+## Directory Purposes
+
+**`src/`:**
+- Purpose: Core pipeline implementation, importable as `src` package
+- Contains: Python modules for each pipeline stage + internal utilities
+- Key files:
+  - `src/main.py`: Pipeline orchestrator (`run_pipeline()`, `main()`)
+  - `src/__main__.py`: Entry point for `python -m src`
+  - `src/telegram_client.py`: Telegram polling + digest delivery
+  - `src/content_fetcher.py`: URL fetching, HTML/PDF extraction, public facade
+  - `src/summarizer.py`: Batch summarization orchestrator with thread pools
+  - `src/digest_generator.py`: Digest Markdown assembly
+  - `src/workflow_commit_strategy.py`: Pure commit mode decision logic
+  - `src/_config.py`: Config dataclasses + `*_from_env()` factories
+  - `src/_types.py`: TypedDict contracts (`FetchResult`, `SummaryResult`, etc.)
+  - `src/_failures.py`: Failure reason constants + `write_failure_record()`
+  - `src/_prompts.py`: `load_prompt()` — reads prompt template files
+  - `src/_url_utils.py`: URL classification, slugification, normalization
+  - `src/CLAUDE.md`: Module-specific AI guidance
+
+**`src/summarization/`:**
+- Purpose: LLM backend implementations for summarization
+- Contains: Protocol definition, OpenRouter backend, NotebookLM backend
+- Key files:
+  - `src/summarization/common.py`: `Summarizer` protocol, `summarize_item()`, `_timeout_result()`
+  - `src/summarization/openrouter_backend.py`: `OpenRouterSummarizer` with free-model discovery, retry, rate-limit spacing
+  - `src/summarization/notebooklm_backend.py`: Async NotebookLM client for YouTube + article fallback
+  - `src/summarization/CLAUDE.md`: Subpackage-specific AI guidance
+
+**`src/telemetry/`:**
+- Purpose: Pipeline observability — metrics emission, log parsing, run history
+- Contains: Metrics dataclass, stdout log parser, GitHub Actions run history subsystem
+- Key files:
+  - `src/telemetry/run_metrics.py`: `RunMetrics` frozen dataclass, `build_run_metrics()`, `to_log_line()`
+  - `src/telemetry/pipeline_log_parser.py`: `extract_pipeline_outputs()` for CI output extraction
+  - `src/telemetry/CLAUDE.md`: Subpackage-specific AI guidance
+
+**`src/telemetry/run_history/`:**
+- Purpose: Fetches past workflow run logs, parses metrics, renders performance table
+- Contains: GitHub API client, log zip parser, snapshot models, report renderer
+- Key files:
+  - `src/telemetry/run_history/github_client.py`: `GitHubActionsClient` — lightweight urllib-based API client
+  - `src/telemetry/run_history/parser.py`: `extract_run_metrics_from_logs_zip()` — parses zipped workflow logs
+  - `src/telemetry/run_history/models.py`: `RunHistorySnapshot` frozen dataclass
+  - `src/telemetry/run_history/report.py`: `fetch_history_snapshots()`, `render_performance_summary()`
+
+**`scripts/`:**
+- Purpose: CI helper scripts invoked as `python -m scripts.<name>`
+- Contains: Pipeline output extraction, commit gate helper, CLAUDE.md sync validator, run history writer
+- Key files:
+  - `scripts/extract_pipeline_outputs.py`: Parses pipeline log, writes GitHub Actions outputs
+  - `scripts/extract_processed_urls.py`: Extracts processed URL count for commit gate
+  - `scripts/validate_claude_sync.py`: Pre-commit hook validating child CLAUDE.md co-staging
+  - `scripts/write_run_history_summary.py`: Fetches history, writes performance table to step summary
+  - `scripts/__init__.py`: Empty package marker
+
+**`tests/`:**
+- Purpose: Unit tests using `unittest` framework
+- Contains: One test file per source module, mirroring `src/` naming
+- Key files:
+  - `tests/test_main.py`: Pipeline orchestration tests
+  - `tests/test_content_fetcher.py`: URL fetching/extraction tests
+  - `tests/test_summarizer.py`: Summarization backend, concurrency, thread safety tests
+  - `tests/test_telegram_client.py`: Polling, URL extraction, chunking, HTML formatting tests
+  - `tests/test_digest_generator.py`: Digest rendering tests
+  - `tests/test_telemetry.py`: Metrics and log parser tests
+  - `tests/test_run_history.py`: Run history snapshot and report tests
+  - `tests/test_workflow_commit_strategy.py`: Commit mode decision tests
+  - `tests/test_ci_scripts.py`: CI script subprocess tests
+  - `tests/test_validate_claude_sync.py`: Pre-commit hook validation tests
+  - `tests/test_youtube_summarizer.py`: YouTube/NotebookLM backend tests
+  - `tests/CLAUDE.md`: Test-specific AI guidance
+
+**`prompts/`:**
+- Purpose: LLM prompt templates controlling output format
+- Contains: Plain text files loaded at runtime by `src/_prompts.py`
+- Key files:
+  - `prompts/summarize.txt`: Article summarization prompt (OpenRouter + NotebookLM fallback)
+  - `prompts/youtube_summarize.txt`: YouTube summarization prompt (NotebookLM)
+  - `prompts/digest.txt`: Digest assembly template with `{{placeholder}}` substitution
+
+**`data/`:**
+- Purpose: Pipeline output artifacts, committed to Git
+- Contains: Date-organized Markdown files + model cache
+- Structure:
+  - `data/digests/YYYY-MM-DD.md`: Daily assembled digests
+  - `data/sources/YYYY-MM-DD/slug.md`: Per-URL summaries
+  - `data/failed/YYYY-MM-DD/slug.md`: Failure records
+  - `data/cache/openrouter_models.json`: TTL-cached model list
+  - `data/replay/notebooklm/pending/YYYY-MM-DD.jsonl`: Replay queue entries
+
+**`.github/workflows/`:**
+- Purpose: GitHub Actions workflow definitions
+- Key files:
+  - `.github/workflows/digest.yml`: Daily pipeline (cron + manual)
+  - `.github/workflows/ci.yml`: Unit tests on push/PR
+  - `.github/workflows/opencode.yml`: AI code review on comment trigger
+  - `.github/CLAUDE.md`: Workflow/scripts-specific AI guidance
+
+**`.githooks/`:**
+- Purpose: Git hooks for development workflow enforcement
+- Key files:
+  - `.githooks/pre-commit`: Runs `scripts/validate_claude_sync.py`
+
+## Key File Locations
+
+**Entry Points:**
+- `src/__main__.py`: Pipeline entry (`python -m src`)
+- `src/main.py:main()`: Pipeline logic entry
+- `scripts/extract_pipeline_outputs.py`: CI output extraction entry
+- `scripts/extract_processed_urls.py`: CI commit gate entry
+- `scripts/write_run_history_summary.py`: CI run history entry
+- `scripts/validate_claude_sync.py`: Pre-commit hook entry
+
+**Configuration:**
+- `pyproject.toml`: Project metadata, dependencies, Python version constraint
+- `uv.lock`: Dependency lockfile
+- `src/_config.py`: Runtime environment variable configuration
+- `.github/workflows/digest.yml`: Workflow-level env vars and secrets
+
+**Core Logic:**
+- `src/main.py`: Pipeline orchestration
+- `src/content_fetcher.py`: URL fetching and content extraction
+- `src/summarizer.py`: Summarization batch orchest
+- `src/summarization/openrouter_backend.py`: OpenRouter LLM integration
+- `src/summarization/notebooklm_backend.py`: NotebookLM LLM integration
+- `src/digest_generator.py`: Digest assembly
+- `src/telegram_client.py`: Telegram API interaction
+
+**Testing:**
+- `tests/`: All test files
+- Run command: `uv run python -m unittest discover -s tests -p "test_*.py"`
+
+**State:**
+- `state.json`: Telegram polling offset (single-field JSON)
+
+## Naming Conventions
+
+**Files:**
+- Pipeline modules: `snake_case.py` (e.g., `content_fetcher.py`, `digest_generator.py`)
+- Internal utilities: `_snake_case.py` with leading underscore (e.g., `_config.py`, `_types.py`, `_url_utils.py`)
+- Test files: `test_<module>.py` mirroring source module name (e.g., `test_main.py` for `main.py`)
+- Prompt templates: `snake_case.txt` (e.g., `summarize.txt`, `youtube_summarize.txt`)
+- Data artifacts: `YYYY-MM-DD.md` for digests, `slug.md` for sources/failures
+
+**Directories:**
+- Subpackages: `snake_case/` (e.g., `summarization/`, `telemetry/`, `run_history/`)
+- Data directories: date-based `YYYY-MM-DD/` subdirectories under `sources/`, `failed/`
+
+**Imports:**
+- All `src/` imports use `from src.X import Y` (absolute, no relative imports except within `run_history/`)
+- `run_history/` uses relative imports internally (`from .github_client import ...`)
+
+## Where to Add New Code
+
+**New Pipeline Stage:**
+- Primary code: `src/<stage_name>.py`
+- TypedDict contract: Add to `src/_types.py`
+- Tests: `tests/test_<stage_name>.py`
+- Wire into: `src/main.py:_run_pipeline_with_context()`
+
+**New Summarization Backend:**
+- Implementation: `src/summarization/<backend_name>_backend.py`
+- Implement the `Summarizer` protocol from `src/summarization/common.py`
+- Wire into: `src/summarizer.py:_build_pipeline_summarizer()` and `summarize_items()`
+- Tests: Add to `tests/test_summarizer.py` or `tests/test_youtube_summarizer.py`
+
+**New CI Script:**
+- Implementation: `scripts/<script_name>.py` with `main()` function and `if __name__ == "__main__"` guard
+- Invoke as: `uv run python -m scripts.<script_name>`
+- Tests: `tests/test_ci_scripts.py` (subprocess-based)
+
+**New Telemetry Metric:**
+- Add field to: `src/telemetry/run_metrics.py:RunMetrics` dataclass
+- Populate in: `src/telemetry/run_metrics.py:build_run_metrics()`
+- Parse in: `src/telemetry/pipeline_log_parser.py:extract_pipeline_outputs()`
+- Update consumers: `.github/workflows/digest.yml` step outputs
+- Tests: `tests/test_telemetry.py`
+
+**New Prompt Template:**
+- File: `prompts/<name>.txt`
+- Load via: `src/_prompts.py:load_prompt("prompts/<name>.txt")`
+- Config path: Add to relevant config dataclass in `src/_config.py`
+
+**New Failure Reason:**
+- Constant: Add to `src/_failures.py`
+- Classify in: `src/content_fetcher.py:_classify_fetch_error()` if fetch-related
+- Use in fallback routing: `src/summarizer.py:_ARTICLE_FETCH_FAILURE_REASONS`
+
+**Utilities:**
+- Shared helpers: `src/_<utility_name>.py` (underscore prefix for internal modules)
+- URL utilities: Extend `src/_url_utils.py`
+- Config: Extend `src/_config.py` with new dataclass + factory
+
+## Special Directories
+
+**`data/`:**
+- Purpose: Pipeline output artifacts (digests, summaries, failures, cache)
+- Generated: Yes — written by pipeline at runtime
+- Committed: Yes — `git add data/` in digest workflow step
+
+**`.claude/worktrees/`:**
+- Purpose: Claude Code worktree copies (development artifacts)
+- Generated: Yes — created by Claude Code tooling
+- Committed: Yes (present in repo)
+
+**`.planning/`:**
+- Purpose: GSD planning documents and codebase analysis
+- Generated: Yes — created by GSD commands
+- Committed: Yes
+
+**`.opencode/`:**
+- Purpose: OpenCode configuration, GSD workflows, and references
+- Generated: Partially
+- Committed: Yes
+
+---
+
+*Structure analysis: 2026-05-31*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,372 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-05-31
+
+## Test Framework
+
+**Runner:**
+- `unittest` (stdlib) — no pytest
+- Config: none (uses default unittest discovery)
+
+**Assertion Library:**
+- `unittest.TestCase` built-in assertions
+
+**Run Commands:**
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"   # Run all tests (CI command)
+uv run python -m unittest tests.test_main                     # Run single test module
+uv run python -m unittest tests.test_summarizer.SummarizerTests.test_summarize_item_writes_source_file_for_article  # Run single test
+```
+
+**CI Integration:**
+- `.github/workflows/ci.yml` runs `uv run python -m unittest discover -s tests -p "test_*.py"` on push/PR to `main`
+- Python 3.11, ubuntu-latest, 10-minute timeout
+
+## Test File Organization
+
+**Location:**
+- Separate `tests/` directory (not co-located with source)
+- One test file per source module, matching name: `src/main.py` → `tests/test_main.py`
+
+**Naming:**
+- Files: `test_<module>.py`
+- Classes: `<Module>Tests` or `<Feature>Tests` (e.g., `SummarizerTests`, `ClampConcurrencyTests`, `ConcurrencySummarizeItemsTests`)
+- Methods: `test_<descriptive_behavior>` (e.g., `test_run_pipeline_returns_empty_day_outcome`, `test_fetch_url_classifies_tls_failures`)
+
+**Structure:**
+```
+tests/
+├── test_main.py                    # Pipeline orchestration (src/main.py)
+├── test_content_fetcher.py         # URL fetching/extraction (src/content_fetcher.py)
+├── test_summarizer.py              # Summarization orchestration (src/summarizer.py)
+├── test_youtube_summarizer.py      # NotebookLM backend (src/summarization/notebooklm_backend.py)
+├── test_digest_generator.py        # Digest assembly (src/digest_generator.py)
+├── test_telegram_client.py         # Telegram API/chunking (src/telegram_client.py)
+├── test_telemetry.py               # Metrics/log parsing (src/telemetry/*)
+├── test_run_history.py             # Run history (src/telemetry/run_history/*)
+├── test_workflow_commit_strategy.py # Commit decisions (src/workflow_commit_strategy.py)
+├── test_ci_scripts.py              # Script entrypoints (scripts/*)
+├── test_validate_claude_sync.py    # Pre-commit hook (scripts/validate_claude_sync.py)
+└── CLAUDE.md                       # Test-specific guidance
+```
+
+## Test Structure
+
+**Suite Organization:**
+```python
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from src.digest_generator import generate_digest
+
+
+class DigestGeneratorTests(unittest.TestCase):
+    def test_generate_digest_writes_dated_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prompt_path = Path(tmpdir) / "digest.txt"
+            prompt_path.write_text("# Digest {{date}}\n\n{{summaries}}\n", encoding="utf-8")
+
+            summary_file = Path(tmpdir) / "summary.md"
+            summary_file.write_text("One summary", encoding="utf-8")
+
+            result = generate_digest(
+                items=[{"status": "ok", "url": "https://example.com/a", "summary_path": str(summary_file)}],
+                run_date=date(2026, 3, 15),
+                prompt_path=str(prompt_path),
+                digests_base_dir=tmpdir,
+            )
+
+            digest_path = Path(result["digest_path"])
+            self.assertTrue(digest_path.exists())
+            self.assertEqual(digest_path.name, "2026-03-15.md")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+**Patterns:**
+- Each test class groups related behavior (e.g., `SummarizerTests`, `ClampConcurrencyTests`, `ConcurrencySummarizeItemsTests`, `OpenRouterThreadSafetyTests`)
+- Multiple test classes per file when testing distinct aspects of the same module
+- `if __name__ == "__main__": unittest.main()` at the bottom of every test file
+- Return type annotation `-> None` on all test methods
+
+## Mocking
+
+**Framework:** `unittest.mock` (stdlib) — `patch`, `MagicMock`, `AsyncMock`
+
+**Patterns:**
+
+1. **Decorator stacking** — Multiple `@patch` decorators for I/O boundaries, applied bottom-up:
+```python
+@patch("src.main.send_digest_from_env")
+@patch("src.main.generate_digest")
+@patch("src.main.summarize_items")
+@patch("src.main.fetch_urls")
+@patch("src.main.poll_urls_from_env")
+def test_run_pipeline_returns_non_empty_outcome(
+    self,
+    mock_poll_urls_from_env,
+    mock_fetch_urls,
+    mock_summarize_items,
+    mock_generate_digest,
+    mock_send_digest_from_env,
+) -> None:
+    mock_poll_urls_from_env.return_value = {
+        "urls": ["https://one.example", "https://two.example"],
+        "update_count": 2,
+        "previous_offset": 10,
+        "next_offset": 12,
+    }
+    mock_fetch_urls.return_value = [...]
+    # ...
+```
+
+2. **Patch at module boundary** — Always patch where the name is looked up, not where defined:
+```python
+@patch("src.content_fetcher.requests.get")      # Correct: patches in consumer module
+@patch("src.content_fetcher.trafilatura.extract") # Correct
+```
+
+3. **`side_effect` for exceptions and dynamic behavior:**
+```python
+mock_fetch_article_text.side_effect = SSLError("certificate verify failed")
+mock_summarize_youtube.side_effect = YouTubeSummaryError(YOUTUBE_AUTH_EXPIRED, "session expired")
+```
+
+4. **`AsyncMock` for async NotebookLM client:**
+```python
+mock_client = AsyncMock()
+mock_client.notebooks = mock_notebooks
+mock_client.sources = mock_sources
+mock_client.chat = mock_chat
+mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+mock_client.__aexit__ = AsyncMock(return_value=False)
+```
+
+5. **Fake/stub classes instead of mocks for protocol implementations:**
+```python
+class _FakeSummarizer:
+    def summarize_article(self, url: str, content: str) -> str:
+        return "article summary for " + url
+
+    def summarize_youtube(self, url: str) -> str:
+        return "youtube summary for " + url
+```
+
+**What to Mock:**
+- Network calls: `requests.get`, `requests.post`, `get_updates`, `_telegram_api`
+- Filesystem: use `tempfile.TemporaryDirectory()` instead of mocking (real temp dirs)
+- Environment variables: `patch.dict(os.environ, {...})` or custom `_override_env()` context manager
+- External SDK clients: `NotebookLMClient`, `OpenRouterSummarizer`
+
+**What NOT to Mock:**
+- Pure functions (URL classification, slug generation, commit strategy decisions)
+- Data transformations (metrics building, log parsing, digest rendering)
+- Use real `tempfile.TemporaryDirectory()` for filesystem tests — don't mock `Path` operations
+
+## Fixtures and Factories
+
+**Test Data:**
+- Inline dict literals matching the `FetchResult`/`SummaryResult` TypedDict contracts:
+```python
+# Fetch result fixture (inline in test)
+{"status": "ok", "kind": "article", "url": "https://example.com/x", "content": "body"}
+{"status": "failed", "kind": "article", "url": "https://x.com/status/123", "error": "x_low_signal_content", "failure_path": "data/failed/2026-03-15/x.md"}
+{"status": "ok", "kind": "youtube", "url": "https://youtu.be/abc"}
+{"status": "ignored", "kind": "unknown", "url": "https://example.com/unsupported"}
+```
+
+- Temporary prompt files written in test setup:
+```python
+with tempfile.TemporaryDirectory() as tmpdir:
+    prompt_path = Path(tmpdir) / "digest.txt"
+    prompt_path.write_text("# Digest {{date}}\n\n{{summaries}}\n", encoding="utf-8")
+```
+
+**Environment Override Helper** (defined in `tests/test_summarizer.py`):
+```python
+@contextlib.contextmanager
+def _override_env(overrides: Dict[str, str]) -> Iterator[None]:
+    """Temporarily set environment variables, restoring originals on exit."""
+    saved: Dict[str, Optional[str]] = {name: os.environ.get(name) for name in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+```
+
+**Usage:**
+```python
+with tempfile.TemporaryDirectory() as tmpdir, _override_env({"OPENROUTER_API_KEY": "key"}):
+    results = summarize_items(items=[...], run_date=date(2026, 3, 15), sources_base_dir=tmpdir)
+```
+
+**Location:**
+- No shared fixture files. All test data is inline or generated in temp directories.
+- No conftest.py (unittest, not pytest).
+
+## Coverage
+
+**Requirements:** None enforced. No coverage tool configured in CI.
+
+**View Coverage:**
+```bash
+uv run python -m coverage run -m unittest discover -s tests -p "test_*.py"
+uv run python -m coverage report
+```
+(Not automated — manual only)
+
+## Test Types
+
+**Unit Tests:**
+- Majority of the test suite. Each module's logic tested in isolation with mocked I/O.
+- Focus on status dict contracts, routing decisions, counts — not formatting details.
+- Files: `tests/test_main.py`, `tests/test_content_fetcher.py`, `tests/test_digest_generator.py`, `tests/test_telegram_client.py`, `tests/test_telemetry.py`, `tests/test_workflow_commit_strategy.py`, `tests/test_validate_claude_sync.py`
+
+**Integration Tests:**
+- `tests/test_ci_scripts.py` — runs scripts as subprocesses via `subprocess.run([sys.executable, "-m", "scripts.<name>"])`, verifying real CLI behavior, exit codes, and stdout/stderr output.
+- `tests/test_summarizer.py` — `ConcurrencySummarizeItemsTests` tests real thread pool behavior with timing assertions.
+- `tests/test_run_history.py` — `RunHistoryFetchTests` uses fake client classes to test multi-step fetch/parse pipeline.
+
+**E2E Tests:**
+- Not used. No browser or full-pipeline E2E tests.
+
+**Concurrency Tests:**
+- `tests/test_summarizer.py` has dedicated concurrency test classes:
+  - `ConcurrencySummarizeItemsTests` — parallel articles + youtube, order preservation, failure isolation between backends
+  - `OpenRouterThreadSafetyTests` — spacing lock, model init race, lock existence on new instances
+  - `SummarizeItemsTimeoutTests` — per-item timeout isolation
+
+```python
+# Concurrency test pattern from tests/test_summarizer.py
+def test_concurrent_articles_and_youtube_run_in_parallel(self, mock_cls, mock_yt) -> None:
+    call_log: list[tuple[str, float]] = []
+    lock = threading.Lock()
+
+    class _SlowArticle:
+        def summarize_article(self, url: str, content: str) -> str:
+            start = time.monotonic()
+            time.sleep(0.05)
+            with lock:
+                call_log.append(("article", start))
+            return "article summary"
+
+    mock_cls.from_config.return_value = _SlowArticle()
+    # ... verify overlapping start times prove parallelism
+```
+
+## Common Patterns
+
+**Async Testing:**
+- `AsyncMock` from `unittest.mock` for async client methods
+- Tests call synchronous wrappers (`summarize_youtube()`) that internally use `asyncio.run()`:
+```python
+@patch("src.summarization.notebooklm_backend.NotebookLMClient")
+def test_happy_path_returns_answer(self, mock_client_cls, mock_resolve) -> None:
+    mock_client = self._make_mock_client("video summary text")
+    mock_client_cls.from_storage = AsyncMock(return_value=mock_client)
+    result = summarize_youtube("https://youtu.be/abc", "Summarize this")
+    self.assertEqual(result, "video summary text")
+```
+
+**Error Testing:**
+- Assert on status dict fields, not exception types:
+```python
+def test_fetch_url_classifies_tls_failures(self, mock_fetch_article_text) -> None:
+    mock_fetch_article_text.side_effect = SSLError("certificate verify failed")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = fetch_url("https://example.com/tls", failed_base_dir=tmpdir)
+    self.assertEqual(result["status"], "failed")
+    self.assertEqual(result["reason"], TLS_ERROR)
+```
+
+- `assertRaises` for functions that raise directly (not status-dict functions):
+```python
+with self.assertRaises(RuntimeError):
+    extract_pipeline_outputs("run_metrics:{}")
+
+with self.assertRaises(YouTubeSummaryError) as ctx:
+    summarize_youtube("https://youtu.be/abc", "Summarize")
+self.assertEqual(ctx.exception.reason, YOUTUBE_AUTH_EXPIRED)
+```
+
+**Subprocess Testing** (for CI scripts):
+```python
+def test_extract_pipeline_outputs_module_writes_github_output(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_path = Path(temp_dir) / "pipeline.log"
+        output_path = Path(temp_dir) / "github_output.txt"
+        log_path.write_text(log_text, encoding="utf-8")
+
+        env = os.environ.copy()
+        env["GITHUB_OUTPUT"] = str(output_path)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "scripts.extract_pipeline_outputs", str(log_path)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+```
+
+**Filesystem Testing:**
+- Always use `tempfile.TemporaryDirectory()` for output directories
+- Verify file existence with `Path(result["summary_path"]).exists()` or `Path(result["failure_path"]).exists()`
+- Read back written content for content assertions
+
+**Stdout Capture:**
+```python
+stdout = io.StringIO()
+with redirect_stdout(stdout):
+    main()
+lines = stdout.getvalue().splitlines()
+run_outcome_lines = [line for line in lines if line.startswith("run_outcome:")]
+```
+
+**Fake Client Pattern** (for testing without mocks):
+```python
+class FakeClient:
+    def list_workflow_runs(self, workflow_file: str, per_page: int = 30):
+        return [{"id": 300, "run_number": 30, "status": "completed", ...}]
+
+    def download_run_logs_zip(self, run_id: int) -> bytes:
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, mode="w") as archive:
+            archive.writestr("job/1.txt", 'run_metrics:{...}')
+        return stream.getvalue()
+```
+
+## Key Testing Guidance
+
+**From `tests/CLAUDE.md`:**
+- Mock at I/O boundaries: network, filesystem, environment. Never hit real APIs.
+- Tests are behavior-focused: assert on status dicts, counts, routing decisions — not formatting.
+- Thread safety matters: `test_summarizer.py` verifies spacing locks, cache init races, and failure isolation under concurrency. Preserve these.
+- Each module has a dedicated test file. New logic needs regression coverage in the matching file.
+- Don't couple tests to unstable formatting unless formatting IS the contract (e.g., digest template).
+
+**When adding tests:**
+1. Identify the matching test file by module name: `src/X.py` → `tests/test_X.py`
+2. Create a new test class if testing a distinct aspect, or add to existing class
+3. Use `tempfile.TemporaryDirectory()` for any filesystem interaction
+4. Mock at the I/O boundary (network, env vars), not internal functions
+5. Assert on the status dict contract (`status`, `kind`, `url`, `error`, `reason`, `failure_path`)
+6. For concurrency-sensitive code, add timing/ordering assertions
+7. For subprocess scripts, test via `subprocess.run()` with `cwd=REPO_ROOT`
+
+---
+
+*Testing analysis: 2026-05-31*

--- a/scripts/commit_strategy.py
+++ b/scripts/commit_strategy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from src.telemetry.pipeline_log_parser import extract_pipeline_outputs
+from src.workflow_commit_strategy import daily_commit_message, decide_commit_mode
+
+
+def _has_staged_changes() -> bool:
+    result = subprocess.run(
+        ["git", "diff", "--staged", "--quiet"],
+        capture_output=True,
+    )
+    return result.returncode != 0
+
+
+def _head_commit_subject() -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def main() -> None:
+    log_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/pipeline.log")
+    try:
+        log_text = log_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"pipeline log not found: {log_path}", file=sys.stderr)
+        raise SystemExit(1)
+    except OSError as exc:
+        print(f"failed to read pipeline log: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        outputs = extract_pipeline_outputs(log_text)
+        processed_urls = int(outputs.get("processed_urls", 0))
+        digest_date = outputs.get("digest_date", "unknown")
+    except RuntimeError as exc:
+        print(f"invalid pipeline log contract: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    except (TypeError, ValueError) as exc:
+        print(f"invalid pipeline log contract: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    expected_subject = daily_commit_message(digest_date)
+    mode = decide_commit_mode(
+        processed_urls=processed_urls,
+        has_staged_changes=_has_staged_changes(),
+        head_commit_subject=_head_commit_subject(),
+        expected_daily_subject=expected_subject,
+    )
+    print(mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,8 +1,8 @@
 # src/
 
-Last-Reviewed-Date: 2026-04-07
-Last-Reviewed-Commit: 0d01b08
-Review-Note: Summarize batches keep diagnostics accurate on noop paths, and enforce mode preserves article overlap while keeping NotebookLM serial auth containment.
+Last-Reviewed-Date: 2026-05-31
+Last-Reviewed-Commit: cd14525
+Review-Note: save_offset now uses atomic write (temp file + replace) to prevent state corruption from partial writes.
 
 Covers `src/` except `src/summarization/` and `src/telemetry/` (routed separately).
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,8 +1,8 @@
 # src/
 
 Last-Reviewed-Date: 2026-05-31
-Last-Reviewed-Commit: cd14525
-Review-Note: save_offset now uses atomic write (temp file + replace) to prevent state corruption from partial writes.
+Last-Reviewed-Commit: af6e7ff
+Review-Note: send_digest now retries sendMessage on transient RequestException (3 attempts, 5s backoff) to prevent lost digests on Telegram outages.
 
 Covers `src/` except `src/summarization/` and `src/telemetry/` (routed separately).
 

--- a/src/telegram_client.py
+++ b/src/telegram_client.py
@@ -34,7 +34,10 @@ def load_offset(state_path: str | Path = "state.json") -> int | None:
 def save_offset(offset: int, state_path: str | Path = "state.json") -> None:
     path = Path(state_path)
     payload = {"telegram_offset": offset}
-    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    content = json.dumps(payload, indent=2) + "\n"
+    temp_path = path.with_suffix(".tmp")
+    temp_path.write_text(content, encoding="utf-8")
+    temp_path.replace(path)
 
 
 def extract_urls(text: str) -> list[str]:

--- a/src/telegram_client.py
+++ b/src/telegram_client.py
@@ -162,7 +162,11 @@ def send_digest(
     digest_text: str,
     parse_mode: str = "HTML",
     max_chunk_length: int = 4096,
+    max_retries: int = 3,
+    retry_backoff_seconds: float = 5.0,
 ) -> list[dict[str, Any]]:
+    import time
+
     sections = _split_digest_sections(digest_text)
     responses: list[dict[str, Any]] = []
 
@@ -180,9 +184,31 @@ def send_digest(
             }
             if parse_mode:
                 body["parse_mode"] = parse_mode
-            responses.append(_telegram_api(bot_token, "sendMessage", body, post=True))
+            response = _send_with_retry(
+                bot_token, body, max_retries=max_retries, backoff_seconds=retry_backoff_seconds,
+            )
+            responses.append(response)
 
     return responses
+
+
+def _send_with_retry(
+    bot_token: str,
+    body: dict[str, Any],
+    max_retries: int,
+    backoff_seconds: float,
+) -> dict[str, Any]:
+    import time
+
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            return _telegram_api(bot_token, "sendMessage", body, post=True)
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt + 1 < max_retries:
+                time.sleep(backoff_seconds * (attempt + 1))
+    raise last_exc  # type: ignore[misc]
 
 
 def _split_digest_sections(digest_text: str) -> list[str]:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,8 +1,8 @@
 # tests/
 
 Last-Reviewed-Date: 2026-05-31
-Last-Reviewed-Commit: cd14525
-Review-Note: Telegram client tests now verify atomic save_offset behavior (no temp file left behind after write).
+Last-Reviewed-Commit: af6e7ff
+Review-Note: Telegram client tests now cover send_digest retry behavior (transient failure recovery, max retries exhaustion).
 
 - Framework: `unittest` with `unittest.mock`. No pytest.
 - Mock at I/O boundaries: network, filesystem, environment. Never hit real APIs.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,8 +1,8 @@
 # tests/
 
 Last-Reviewed-Date: 2026-05-31
-Last-Reviewed-Commit: d2177d2
-Review-Note: CI script tests now cover commit_strategy.py entrypoint (skip on zero processed URLs, missing log file handling).
+Last-Reviewed-Commit: cd14525
+Review-Note: Telegram client tests now verify atomic save_offset behavior (no temp file left behind after write).
 
 - Framework: `unittest` with `unittest.mock`. No pytest.
 - Mock at I/O boundaries: network, filesystem, environment. Never hit real APIs.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,8 +1,8 @@
 # tests/
 
-Last-Reviewed-Date: 2026-05-12
-Last-Reviewed-Commit: d182cea
-Review-Note: NotebookLM preflight tests cover auth-like ValueError classification separately from non-auth backend failures.
+Last-Reviewed-Date: 2026-05-31
+Last-Reviewed-Commit: d2177d2
+Review-Note: CI script tests now cover commit_strategy.py entrypoint (skip on zero processed URLs, missing log file handling).
 
 - Framework: `unittest` with `unittest.mock`. No pytest.
 - Mock at I/O boundaries: network, filesystem, environment. Never hit real APIs.

--- a/tests/test_ci_scripts.py
+++ b/tests/test_ci_scripts.py
@@ -197,6 +197,42 @@ class ScriptEntrypointTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("invalid pipeline log contract", result.stderr)
 
+    def test_commit_strategy_prints_skip_when_no_processed_urls(self) -> None:
+        log_text = (
+            'run_outcome:{"processed_urls": 0, "summary_ok_count": 0, "summary_failed_count": 0, '
+            '"digest_created": false, "digest_path": "", "digest_sent_chunks": 0}\n'
+            'run_metrics:{"metrics_version": 1, "digest_date": "2026-03-22", "processed_urls": 0}'
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "pipeline.log"
+            log_path.write_text(log_text, encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, "-m", "scripts.commit_strategy", str(log_path)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+            self.assertEqual(result.stdout.strip(), "skip")
+
+    def test_commit_strategy_fails_when_log_file_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_log_path = Path(temp_dir) / "missing.log"
+            result = subprocess.run(
+                [sys.executable, "-m", "scripts.commit_strategy", str(missing_log_path)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("pipeline log not found", result.stderr)
+
     def test_replay_notebooklm_failures_module_handles_empty_queue(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             replay_base = Path(temp_dir) / "replay"

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -4,6 +4,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import requests
+
 from src.telegram_client import chunk_text_by_paragraph, extract_urls, load_offset, poll_urls, save_offset, send_digest
 
 
@@ -183,6 +185,34 @@ class TelegramClientTests(unittest.TestCase):
         self.assertIn("<b>Item 1</b>", sent_texts[0])
         self.assertIn("<b>Item 2</b>", sent_texts[-1])
         self.assertNotIn("<b>Item 2</b>", "\n".join(sent_texts[:-1]))
+
+
+    @patch("src.telegram_client._telegram_api")
+    def test_send_digest_retries_on_transient_failure(self, mock_api) -> None:
+        mock_api.side_effect = [
+            requests.exceptions.ConnectionError("connection refused"),
+            {"ok": True, "result": {"message_id": 1}},
+        ]
+
+        responses = send_digest(
+            bot_token="token", chat_id=123, digest_text="hello",
+            retry_backoff_seconds=0.01,
+        )
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(mock_api.call_count, 2)
+
+    @patch("src.telegram_client._telegram_api")
+    def test_send_digest_raises_after_max_retries(self, mock_api) -> None:
+        mock_api.side_effect = requests.exceptions.ConnectionError("connection refused")
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            send_digest(
+                bot_token="token", chat_id=123, digest_text="hello",
+                max_retries=2, retry_backoff_seconds=0.01,
+            )
+
+        self.assertEqual(mock_api.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -26,6 +26,14 @@ class TelegramClientTests(unittest.TestCase):
             save_offset(538711799, state_path)
             self.assertEqual(load_offset(state_path), 538711799)
 
+    def test_save_offset_does_not_leave_temp_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_offset(12345, state_path)
+            temp_path = state_path.with_suffix(".tmp")
+            self.assertFalse(temp_path.exists())
+            self.assertEqual(load_offset(state_path), 12345)
+
     @patch("src.telegram_client.get_updates")
     def test_poll_urls_advances_offset_plus_one(self, mock_get_updates) -> None:
         mock_get_updates.return_value = [


### PR DESCRIPTION
## What

Four changes that ensure pipeline outputs survive reliably:

1. **Commit strategy script** — `scripts/commit_strategy.py` wraps `decide_commit_mode()` for CI use, supporting skip/create/amend modes.

2. **Workflow amend on same-day re-runs** — `digest.yml` now uses `scripts/commit_strategy.py` to decide mode. Same-day re-runs `--amend` instead of creating duplicate commits.

3. **Atomic offset write** — `save_offset()` writes to a temp file then `os.replace()`. Prevents corruption from partial writes.

4. **Digest delivery retry** — `send_digest()` retries `sendMessage` on transient `RequestException` (3 attempts, 5s backoff). Prevents lost digests on Telegram outages.

## Commits
- feat: add commit strategy script entrypoint
- fix: digest.yml uses amend on same-day re-runs
- fix: atomic write for telegram offset state
- fix: retry digest delivery on transient failure

## Testing
- CI script tests cover commit_strategy.py (skip mode, missing log)
- Telegram client tests cover atomic write and retry behavior
- All 137 tests pass